### PR TITLE
Remove debug fields from `CalStep` objects

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -7,9 +7,13 @@
 * Complete rewrite of MASS for version 2. Base data wrangling on [Pola.rs](https://pola.rs/).
 * Allow `Channel` objects to have callable to transform raw data (e.g., by inverting it) (issue 12).
 * Raise minimum python version to 3.10 for type annotations to work.
-* Support reading LJH file version 2.2, 2.1, and 2.0, and also OFF versions 0.1, 0.2, and 0.3.
-* Use mass1-style noise analysis, where (if available), continuous noise is used to estimate high-lag autocorrelation better.
-* Add `FilterMaker.compute_5lag_noexp()` and `.compute_5lag_constrained()` for constrained optimal filters.
+* Make mypy type annotation tests run without errors.
+* Support reading LJH file version 2.2, 2.1, and 2.0 (issue 26), and also OFF versions 0.1, 0.2, and 0.3.
+* Use mass1-style noise analysis, where (if available), continuous noise is used to estimate high-lag autocorrelation better
+  (issue 24).
+* Add `FilterMaker.compute_5lag_noexp()` and `.compute_5lag_constrained()` for constrained optimal filters (issue 29).
+* Read external trigger times into the Mass2 dataframe (issue 28).
+* Add `CalSteps.trim_dead_ends()` to generate a recipe that removes steps not needed to reach a certain end (issue 38).
 
 
 ## Mass Version 1 (2010-2025)

--- a/mass2/core/cal_steps.py
+++ b/mass2/core/cal_steps.py
@@ -202,7 +202,7 @@ class CalSteps:
         # return a new CalSteps with the step added, no mutation!
         return CalSteps(self.steps + [step])
 
-    def trim_dead_ends(self, required_fields: Iterable[str]) -> "CalSteps":
+    def trim_dead_ends(self, required_fields: Iterable[str] | str) -> "CalSteps":
         """Create a new CalSteps object with all dead-end steps removed.
 
         Dead-end steps are defined as any step that can be omitted without affecting the ability to
@@ -214,7 +214,7 @@ class CalSteps:
 
         Parameters
         ----------
-        required_fields : list[str] | tuple[str] | set[str]
+        required_fields : Iterable[str] | str
             Steps will be preserved if any of their outputs are among `required_fields`, or if their outputs are
             found recursively among the inputs to any such steps.
 
@@ -222,14 +222,9 @@ class CalSteps:
         -------
         CalSteps
             A copy of `self`, except that any steps not required to compute any of `required_fields` is omitted.
-
-        Raises
-        ------
-        ValueError
-            if the argument is a single string (it should be a tuple, list, or set of strings)
         """
         if isinstance(required_fields, str):
-            raise ValueError("CalSteps.trim_dead_ends(rf) wants rf to be Iterable[str], but was passed a string")
+            required_fields = [required_fields]
 
         all_fields_out: set[str] = set(required_fields)
         nsteps = len(self)

--- a/mass2/core/cal_steps.py
+++ b/mass2/core/cal_steps.py
@@ -15,6 +15,10 @@ class CalStep:
     use_expr: pl.Expr
 
     @property
+    def name(self):
+        return type(self)
+
+    @property
     def description(self):
         return f"{type(self).__name__} inputs={self.inputs} outputs={self.output}"
 
@@ -238,8 +242,6 @@ class CalSteps:
                 if field in all_fields_out:
                     required[istep] = True
                     all_fields_out.update(step.inputs)
-                    print(f"We require step #{istep}")
-                    print(all_fields_out)
                     break
 
         if np.all(required):

--- a/mass2/core/filter_steps.py
+++ b/mass2/core/filter_steps.py
@@ -1,6 +1,6 @@
 import polars as pl
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from collections.abc import Callable
 from mass2.core.cal_steps import CalStep
 from mass2.core.noise_algorithms import NoiseResult
@@ -10,7 +10,7 @@ from mass2.core.optimal_filtering import Filter, FilterMaker
 @dataclass(frozen=True)
 class Filter5LagStep(CalStep):
     filter: Filter
-    spectrum: NoiseResult
+    spectrum: NoiseResult | None
     filter_maker: "FilterMaker"
     transform_raw: Callable | None = None
 
@@ -28,3 +28,6 @@ class Filter5LagStep(CalStep):
 
     def dbg_plot(self, _):
         return self.filter.plot()
+
+    def drop_debug(self):
+        return replace(self, spectrum=None)

--- a/mass2/core/rough_cal.py
+++ b/mass2/core/rough_cal.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 import numpy as np
 import pylab as plt  # type: ignore
 import polars as pl
@@ -663,7 +663,7 @@ def eval_3peak_assignment_pfit_gain(ph_assigned, e_assigned, possible_phs, line_
 
 @dataclass(frozen=True)
 class RoughCalibrationStep(CalStep):
-    pfresult: SmoothedLocalMaximaResult
+    pfresult: SmoothedLocalMaximaResult | None
     assignment_result: BestAssignmentPfitGainResult | None
     ph2energy: typing.Callable
     success: bool
@@ -675,6 +675,9 @@ class RoughCalibrationStep(CalStep):
         out = self.ph2energy(inputs_np[0])
         df2 = pl.DataFrame({self.output[0]: out}).with_columns(df)
         return df2
+
+    def drop_debug(self):
+        return replace(self, pfresult=None, assignment_result=None)
 
     def dbg_plot_old(self, df, bin_edges=np.arange(0, 10000, 1), axis=None, plotkwarg={}):
         series = mass2.misc.good_series(df, col=self.output[0], good_expr=self.good_expr, use_expr=self.use_expr)

--- a/tests/core/test_stuff.py
+++ b/tests/core/test_stuff.py
@@ -434,5 +434,5 @@ def test_steps():
     for i, expect in enumerate((True, False, True, False, False)):
         assert (steps[i] in trim_steps) == expect
 
-    with pytest.raises(ValueError):
-        steps.trim_dead_ends("this is a string, not a list")
+    no_steps = steps.trim_dead_ends("this field doesn't exist")
+    assert len(no_steps) == 0


### PR DESCRIPTION
Not ready to merge yet--it still needs some tests. But take a look. This was pretty darn simple, so I hope that you'll be okay with this even if you think it superfluous.

Also, sorry. It accidentally builds on the work from PR #39. If you like, we can merge that and make it easier to review this one.