### PR TITLE
Added a way to compute and apply an Arrival-Time-Safe filter as a `RecipeStep`

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -45,6 +45,8 @@ jobs:
         activate-environment: true
         python-version: ${{ matrix.python-version }}
         enable-cache: true
+        ignore-nothing-to-cache: true
+        prune-cache: false
         cache-dependency-glob: |
           **/uv.lock
           **/pyproject.toml

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -51,14 +51,6 @@ jobs:
           **/uv.lock
           **/pyproject.toml
 
-    - name: Report if the cache was restored
-      if: steps.setup-uv.outputs.cache-hit == 'true'
-      run: echo "Cache was restored"
-
-    - name: Report if the cache was NOT restored
-      if: steps.setup-uv.outputs.cache-hit != 'true'
-      run: echo "Cache was NOT restored"
-
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"
 

--- a/mass2/core/filter_steps.py
+++ b/mass2/core/filter_steps.py
@@ -1,5 +1,5 @@
 """
-Provide `Filter5LagStep`, a step to apply a 5-lag optimal filter to pulse data in a DataFrame.
+Provide `OptimalFilterStep`, a step to apply an optimal filter to pulse data in a DataFrame.
 """
 
 import polars as pl
@@ -15,7 +15,7 @@ from mass2.core.optimal_filtering import Filter, FilterMaker
 
 @dataclass(frozen=True)
 class OptimalFilterStep(RecipeStep):
-    """A step to apply a 5-lag optimal filter to pulse data in a DataFrame."""
+    """A step to apply an optimal filter to pulse data in a DataFrame."""
 
     filter: Filter
     spectrum: NoiseResult | None
@@ -23,7 +23,7 @@ class OptimalFilterStep(RecipeStep):
     transform_raw: Callable | None = None
 
     def calc_from_df(self, df: pl.DataFrame) -> pl.DataFrame:
-        """Apply the 5-lag optimal filter to the input DataFrame and return a new DataFrame with results."""
+        """Apply the optimal filter to the input DataFrame and return a new DataFrame with results."""
         dfs = []
         for df_iter in df.iter_slices(10000):
             raw = df_iter[self.inputs[0]].to_numpy()

--- a/mass2/core/optimal_filtering.py
+++ b/mass2/core/optimal_filtering.py
@@ -453,8 +453,9 @@ class FilterATS(Filter):
 
 
 @njit
-def _filter_records_ats(x: ArrayLike, values: NDArray, dt_values: NDArray) -> tuple[float, float]:
+def _filter_records_ats(x: NDArray, values: NDArray, dt_values: NDArray) -> tuple[np.ndarray, np.ndarray]:
     "A numba-JIT speedup of the core computation"
+    x = x.astype(values.dtype)
     conv0 = np.dot(x, values)
     conv1 = np.dot(x, dt_values)
     arrival_time = conv1 / conv0

--- a/tests/core/test_stuff.py
+++ b/tests/core/test_stuff.py
@@ -19,8 +19,8 @@ def test_ljh_to_polars():
 def dummy_channel(npulses=100, seed=4, signal=np.zeros(50, dtype=np.int16)):
     rng = np.random.default_rng(seed)
     n = len(signal)
-    noise_traces = np.asarray(rng.standard_normal((npulses, n)) * 10 + 5000, dtype=np.int16)
-    pulse_traces = np.tile(signal, (npulses, 1)) + noise_traces
+    noise_traces = np.asarray(rng.standard_normal((npulses, n)) * 20 + 5000, dtype=np.int16)
+    pulse_traces = np.outer(rng.uniform(0.8, 1.2, size=npulses), signal).astype(np.int16)
     header_df = pl.DataFrame()
     frametime_s = 1e-5
     df_noise = pl.DataFrame({"pulse": noise_traces})
@@ -33,7 +33,7 @@ def dummy_channel(npulses=100, seed=4, signal=np.zeros(50, dtype=np.int16)):
         n_samples=n,
         df=header_df,
     )
-    df = pl.DataFrame({"pulse": pulse_traces})
+    df = pl.DataFrame({"pulse": pulse_traces + noise_traces})
     ch = mass2.Channel(df, header, npulses=npulses, noise=noise_ch)
     return ch
 
@@ -342,7 +342,7 @@ def test_select_step():
 def test_filtering_steps():
     "Make sure we can compute and apply both 5-lag and ATS-type optimal filters."
     t = np.arange(-25, 25)
-    signal = 2000 * (np.exp(-t / 8) - np.exp(t / 1))
+    signal = 10000 * (np.exp(-t / 12.0) - np.exp(-t / 3.0))
     signal[t < 0] = 0
     ch = dummy_channel(npulses=100, signal=signal)
     ch = ch.filter5lag(f_3db=20000)

--- a/tests/core/test_stuff.py
+++ b/tests/core/test_stuff.py
@@ -339,6 +339,19 @@ def test_select_step():
         assert isinstance(steps2[0][0], mass2.core.recipe.SelectStep)
 
 
+def test_filtering_steps():
+    "Make sure we can compute and apply both 5-lag and ATS-type optimal filters."
+    t = np.arange(-25, 25)
+    signal = 2000 * (np.exp(-t / 8) - np.exp(t / 1))
+    signal[t < 0] = 0
+    ch = dummy_channel(npulses=100, signal=signal)
+    ch = ch.filter5lag(f_3db=20000)
+    ch = ch.summarize_pulses()
+    ch = ch.filterATS(f_3db=20000)
+    for field in ("5lagy", "5lagx", "ats_x", "ats_y"):
+        assert not (np.allclose(ch.df[field].to_numpy().mean(), 0))
+
+
 def test_categorize_step():
     ch = dummy_channel(npulses=10)
     ch = ch.with_columns(pl.DataFrame({"a": np.arange(len(ch.df)), "b": np.arange(len(ch.df)) * 2}))


### PR DESCRIPTION
This addition fixes #67.
Also figured out how to cache `pulsedata` at GitHub Actions. Yay! Fixes #61.