### PR TITLE
Annotate scatter plots with mouseover and clickable features

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -9,6 +9,7 @@
 * Require `numpy` version >= 2.0.
 * Improve README installation instructions.
 * Add a save/restore function for in-progress analysis (issue 70).
+* Add mouseover and clickable features to scatter plots (issue 71).
 
 **2.0.0 beta 2** September 3, 2025
 

--- a/examples/bessy_20240727.py
+++ b/examples/bessy_20240727.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.14.16"
+__generated_with = "0.15.2"
 app = marimo.App(width="medium", app_title="MASS v2 intro")
 
 
@@ -72,26 +72,6 @@ def _(mo):
 
 
 @app.cell
-def _(data2):
-    data2.ch0.df.columns
-    return
-
-
-@app.cell
-def _(data3, mass2):
-    data3.ch0.plot_scatter("timestamp", "energy_pulse_rms", color_col="state_label")
-    mass2.show()
-    return
-
-
-@app.cell
-def _(data3, mass2):
-    data3.ch0.plot_scatter("energy_5lagy_dc", "5lagy_dc", color_col="state_label")
-    mass2.show()
-    return
-
-
-@app.cell
 def _(data, mass2):
     def _do_analysis(ch: mass2.Channel) -> mass2.Channel:
         return ch.summarize_pulses().with_good_expr_pretrig_rms_and_postpeak_deriv()
@@ -99,6 +79,12 @@ def _(data, mass2):
     data2 = data.map(_do_analysis)
     data2 = data2.with_experiment_state_by_path()
     return (data2,)
+
+
+@app.cell
+def _(data2):
+    data2.ch0.df.columns
+    return
 
 
 @app.cell
@@ -128,6 +114,20 @@ def _(data2, mass2, pl):
 
     data3 = data2.map(_do_analysis)
     return (data3,)
+
+
+@app.cell
+def _(data3, mass2):
+    data3.ch0.plot_scatter("timestamp", "energy_pulse_rms", color_col="state_label")
+    mass2.show()
+    return
+
+
+@app.cell
+def _(data3, mass2):
+    data3.ch0.plot_scatter("energy_5lagy_dc", "5lagy_dc", color_col="state_label")
+    mass2.show()
+    return
 
 
 @app.cell

--- a/mass2/core/channel.py
+++ b/mass2/core/channel.py
@@ -11,6 +11,7 @@ import os
 import lmfit
 import polars as pl
 import pylab as plt
+from matplotlib.backend_bases import MouseEvent
 import marimo as mo
 import functools
 import numpy as np
@@ -247,26 +248,103 @@ class Channel:
         use_good_expr: bool = True,
         skip_none: bool = True,
         ax: plt.Axes | None = None,
+        annotate: bool = True,
     ) -> None:
-        """Generate a scatter plot of `y_col` vs `x_col`, optionally colored by `color_col`."""
+        (
+            """Generate a scatter plot of `y_col` vs `x_col`, optionally colored by `color_col`.
+
+        Parameters
+        ----------
+        x_col : str
+            Name of the column to put on the x axis
+        y_col : str
+            Name of the column to put on the y axis
+        color_col : str | None, optional
+            Name of the column to color points by (generally a category like "state_label"), by default None
+        use_expr : pl.Expr, optional
+            An expression to select plottable points, by default pl.lit(True)
+        use_good_expr : bool, optional
+            Whether to apply the object's `good_expr` before plotting, by default True
+        skip_none : bool, optional
+            Whether to skip color categories with no name, by default True
+        ax : plt.Axes | None, optional
+            Axes to plot on, by default None
+        annotate : bool, optional
+            Whether to annotate points that are hovered over or clicked on by the mouse, by default False
+        """
+            """"""
+        )
         if ax is None:
-            plt.figure()
+            fig = plt.figure()
             ax = plt.gca()
         plt.sca(ax)  # set current axis so I can use plt api
+        fig = plt.gcf()
+        filter_expr = use_expr
         if use_good_expr:
             filter_expr = self.good_expr.and_(use_expr)
-        else:
-            filter_expr = self.good_expr
-        df_small = self.df.lazy().filter(filter_expr).select(x_col, y_col, color_col).collect()
+        df_small = self.df.lazy().with_row_index(name="index").filter(filter_expr).select(x_col, y_col, color_col, "index").collect()
+        lines_pnums: list[tuple[plt.Line2D, pl.Series]] = []
         for (name,), data in df_small.group_by(color_col, maintain_order=True):
             if name is None and skip_none and color_col is not None:
                 continue
-            plt.plot(
+            (line,) = plt.plot(
                 data.select(x_col).to_series(),
                 data.select(y_col).to_series(),
                 ".",
                 label=name,
             )
+            lines_pnums.append((line, data.select("index").to_series()))
+
+        if annotate:
+            annotation = ax.annotate(
+                "",
+                xy=(0, 0),
+                xytext=(-20, 20),
+                textcoords="offset points",
+                bbox=dict(boxstyle="round", fc="w"),
+                arrowprops=dict(arrowstyle="->"),
+            )
+            annotation.set_visible(False)
+
+            def update_note(points: list) -> None:
+                # TODO: this only works if the first line object has the pulse we want.
+                line, pnum = lines_pnums[0]
+                x, y = line.get_data()
+                annotation.xy = (x[points[0]], y[points[0]])
+                text2 = " ".join([str(pnum[int(n)]) for n in points])
+                if len(points) > 1:
+                    text = f"Pulses [{text2}]"
+                else:
+                    text = f"Pulse {text2}"
+                annotation.set_text(text)
+                annotation.get_bbox_patch().set_alpha(0.75)
+
+            def hover(event: MouseEvent) -> None:
+                vis = annotation.get_visible()
+                if event.inaxes != ax:
+                    return
+                cont, ind = line.contains(event)
+                if cont:
+                    update_note(ind["ind"])
+                    annotation.set_visible(True)
+                    fig.canvas.draw_idle()
+                elif vis:
+                    annotation.set_visible(False)
+                    fig.canvas.draw_idle()
+
+            def click(event: MouseEvent) -> None:
+                if event.inaxes != ax:
+                    return
+                cont, ind = line.contains(event)
+                if cont:
+                    pnum = lines_pnums[0][1]
+                    rownum = pnum[int(ind["ind"][0])]
+                    print(f"This is pulse# {rownum}")
+                    print(self.df.drop("pulse").row(rownum, named=True))
+
+            fig.canvas.mpl_connect("motion_notify_event", hover)
+            fig.canvas.mpl_connect("button_press_event", click)
+
         plt.xlabel(str(x_col))
         plt.ylabel(str(y_col))
         title_str = f"""{self.header.description}

--- a/mass2/core/channel.py
+++ b/mass2/core/channel.py
@@ -250,8 +250,7 @@ class Channel:
         ax: plt.Axes | None = None,
         annotate: bool = True,
     ) -> None:
-        (
-            """Generate a scatter plot of `y_col` vs `x_col`, optionally colored by `color_col`.
+        """Generate a scatter plot of `y_col` vs `x_col`, optionally colored by `color_col`.
 
         Parameters
         ----------
@@ -270,10 +269,8 @@ class Channel:
         ax : plt.Axes | None, optional
             Axes to plot on, by default None
         annotate : bool, optional
-            Whether to annotate points that are hovered over or clicked on by the mouse, by default False
+            Whether to annotate points that are hovered over or clicked on by the mouse, by default True
         """
-            """"""
-        )
         if ax is None:
             fig = plt.figure()
             ax = plt.gca()
@@ -307,6 +304,13 @@ class Channel:
             annotation.set_visible(False)
 
             def update_note(points: list) -> None:
+                """Generate a matplotlib hovering note about the data point index
+
+                Parameters
+                ----------
+                points : list
+                    List of the plotted data points that are hovered over
+                """
                 # TODO: this only works if the first line object has the pulse we want.
                 line, pnum = lines_pnums[0]
                 x, y = line.get_data()
@@ -320,6 +324,13 @@ class Channel:
                 annotation.get_bbox_patch().set_alpha(0.75)
 
             def hover(event: MouseEvent) -> None:
+                """Callback to be used when mouse hovers near a plotted point
+
+                Parameters
+                ----------
+                event : MouseEvent
+                    The mouse-related event; contains location information
+                """
                 vis = annotation.get_visible()
                 if event.inaxes != ax:
                     return
@@ -333,6 +344,13 @@ class Channel:
                     fig.canvas.draw_idle()
 
             def click(event: MouseEvent) -> None:
+                """Callback to be used when mouse clicks near a plotted point
+
+                Parameters
+                ----------
+                event : MouseEvent
+                    The mouse-related event; contains location information
+                """
                 if event.inaxes != ax:
                     return
                 cont, ind = line.contains(event)


### PR DESCRIPTION
We can probably do better, but here's a sweet demonstration of how to make data scatter plots where:
* Hovering the mouse over (or near) a data point pops up facts about that point on the graph
* Clicking the mouse on (or near) a data point prints text about it to the terminal: the full contents of the data frame row.

Fixes #71.