### PR TITLE
keep subframecount and timestamp in save_analysis by default

### DIFF
--- a/mass2/core/channel.py
+++ b/mass2/core/channel.py
@@ -704,7 +704,8 @@ class Channel:
             _description_
         """
         avg_pulse = (
-            self.df.lazy()
+            self.df
+            .lazy()
             .filter(self.good_expr)
             .filter(use_expr)
             .select(pulse_col)
@@ -793,7 +794,8 @@ class Channel:
             _description_
         """
         df = (
-            self.df.lazy()
+            self.df
+            .lazy()
             .filter(self.good_expr)
             .filter(use_expr)
             .limit(limit)
@@ -997,7 +999,8 @@ class Channel:
         assert off._mmap is not None
         df = pl.from_numpy(np.asarray(off._mmap))
         df = (
-            df.select(pl.from_epoch("unixnano", time_unit="ns").dt.cast_time_unit("us").alias("timestamp"))
+            df
+            .select(pl.from_epoch("unixnano", time_unit="ns").dt.cast_time_unit("us").alias("timestamp"))
             .with_columns(df)
             .select(pl.exclude("unixnano"))
         )
@@ -1029,7 +1032,8 @@ class Channel:
     def with_external_trigger_df(self, df_ext: pl.DataFrame) -> "Channel":
         """Add external trigger times from an existing dataframe"""
         df2 = (
-            self.df.with_columns(subframecount=pl.col("framecount") * self.subframediv)
+            self.df
+            .with_columns(subframecount=pl.col("framecount") * self.subframediv)
             .join_asof(df_ext, on="subframecount", strategy="backward", coalesce=False, suffix="_prev_ext_trig")
             .join_asof(df_ext, on="subframecount", strategy="forward", coalesce=False, suffix="_next_ext_trig")
         )

--- a/mass2/core/channels.py
+++ b/mass2/core/channels.py
@@ -691,7 +691,9 @@ class Channels:
             )
         return Channels(channels, description)
 
-    def save_analysis(self, zip_path: Path | str, overwrite: bool = False, trim_debug: bool = False, trim_timestamp_and_subframecount: bool = False) -> None:
+    def save_analysis(
+        self, zip_path: Path | str, overwrite: bool = False, trim_debug: bool = False, trim_timestamp_and_subframecount: bool = False
+    ) -> None:
         """Save an analysis-in-progress completely to a zip file, only tested for ljh backed channels so far
 
         Parameters
@@ -703,7 +705,7 @@ class Channels:
         trim_debug : bool, optional
             Whether to make save file smaller (potentially) at the cost of breaking some debugging plots, by default False
         trim_timestamp_and_subframecount: bool, optional
-            Whether to make the save file smaller at the cost of reduced information avaialble when the ljh files are 
+            Whether to make the save file smaller at the cost of reduced information avaialble when the ljh files are
             not available, eg when loading on another computer.
         """
         zip_path = pathlib.Path(zip_path)

--- a/mass2/core/rough_cal.py
+++ b/mass2/core/rough_cal.py
@@ -56,7 +56,8 @@ def rank_3peak_assignments(
     df1 = df1.filter((pl.col("e0") < pl.col("e1")).and_(pl.col("ph0") < pl.col("ph1")))
     # 2) the gain slope must be negative
     df1 = (
-        df1.with_columns(gain1=pl.col("ph1") / pl.col("e1"))
+        df1
+        .with_columns(gain1=pl.col("ph1") / pl.col("e1"))
         .with_columns(gain_slope=(pl.col("gain1") - pl.col("gain0")) / (pl.col("ph1") - pl.col("ph0")))
         .filter(pl.col("gain_slope") < 0)
     )

--- a/mass2/core/truebq_bin.py
+++ b/mass2/core/truebq_bin.py
@@ -81,7 +81,8 @@ class TriggerResult:
 
         # trigger indices (raw) → restrict to plotted window → convert to decimated indices
         trig_inds_raw = (
-            pl.DataFrame({"trig_inds": self.trig_inds})
+            pl
+            .DataFrame({"trig_inds": self.trig_inds})
             .filter(pl.col("trig_inds").is_between(raw_start, raw_stop))
             .to_series()
             .to_numpy()

--- a/tests/core/test_multifit.py
+++ b/tests/core/test_multifit.py
@@ -54,7 +54,8 @@ def generate_and_fit_fake_data(
 
     # Set up MultiFit
     multifit = (
-        mass2.MultiFit(default_fit_width=80, default_bin_size=1)
+        mass2
+        .MultiFit(default_fit_width=80, default_bin_size=1)
         .with_line("MnKAlpha")
         .with_line(gaussian_centers_ev[0])
         .with_line(gaussian_centers_ev[1])

--- a/tests/core/test_stuff.py
+++ b/tests/core/test_stuff.py
@@ -429,7 +429,8 @@ def test_steps():
     # Perform 5 offical Recipe: summarize, filter, a pointless "squareme" step, drift correction, and another pointless one.
     def _do_steps(ch: mass2.Channel) -> mass2.Channel:
         return (
-            ch.summarize_pulses()
+            ch
+            .summarize_pulses()
             .with_good_expr_pretrig_rms_and_postpeak_deriv(8, 8)
             .filter5lag(f_3db=10000)
             .with_column_map_step("pretrig_rms", "pointless_pretrig_meansq", squareme)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -17,7 +17,8 @@ def load_data():
 def all_steps(ch: mass2.Channel) -> mass2.Channel:
     use_dc = pl.lit(True)
     return (
-        ch.summarize_pulses()
+        ch
+        .summarize_pulses()
         .with_good_expr_pretrig_rms_and_postpeak_deriv(8, 8)
         .filter5lag(f_3db=10000)
         .driftcorrect(indicator_col="pretrig_mean", uncorrected_col="5lagy", use_expr=use_dc)


### PR DESCRIPTION
We've been using save_analysis to move analyzed data from one computer to another, and it's quite useful to have the subframecount and timestamp. So by default, do not trim them.

Just look at the first commit to ignore the formatting changes.