### PR TITLE
Time drift correct

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -7,7 +7,9 @@
 * Some improvements to plotting:
   * Remove `plt.tight_layout()` in mass; prefer user set `figure.constrained_layout.use : True` in matplotlibrc.
   * Set most mass plots to call `plot_zoomable`, which turns on mouse zooming (same as typing 'O' in window).
+  * Fix bugs: failing to plot channel histograms on existing axes.
 * Make the parameters `cut_pre` and `cut_post` work with Fourier-domain filters.
+* Make a recipe step to use the time-drift-correct algorithm.
 
 **2.0.3** March 13, 2026
 * Add some convenient plotting features like `Channel.plot_pulses()`.

--- a/mass2/core/__init__.py
+++ b/mass2/core/__init__.py
@@ -31,7 +31,7 @@ from .multifit import (
 from . import filter_steps
 from .filter_steps import OptimalFilterStep
 from .optimal_filtering import FilterMaker, Filter, ToeplitzWhitener
-from .drift_correction import drift_correct, DriftCorrectStep
+from .drift_correction import drift_correct, DriftCorrectStep, TimeDriftCorrectStep
 from . import rough_cal
 from .channel import Channel, ChannelHeader, BadChannel
 from .truebq_bin import TrueBqBin

--- a/mass2/core/channel.py
+++ b/mass2/core/channel.py
@@ -31,7 +31,7 @@ from .misc import alwaysTrue, plot_zoomable
 from .multifit import MultiFit, MultiFitQuadraticGainStep, MultiFitMassCalibrationStep
 from .filter_steps import OptimalFilterStep
 from .optimal_filtering import FilterMaker
-from .drift_correction import DriftCorrectStep
+from .drift_correction import DriftCorrectStep, TimeDriftCorrectStep
 from .recipe import Recipe, RecipeStep, SummarizeStep
 from .noise_channel import NoiseChannel
 
@@ -1197,6 +1197,20 @@ class Channel:
             corrected_col=corrected_col,
             use_expr=use_expr,
         )
+        return self.with_step(step)
+
+    def time_drift_correct(
+        self,
+        time_col: str = "timestamp",
+        uncorrected_col: str = "5lagy_dc",
+        corrected_col: str = "5lagy_tdc",
+        use_expr: pl.Expr = pl.lit(True),
+    ) -> "Channel":
+        """Correct for gain drifing slowly with time."""
+        # by defining a seperate learn method that takes ch as an argument,
+        # we can move all the code for the step outside of Channel
+        step = TimeDriftCorrectStep.learn(ch=self, time_col=time_col, uncorrected_col=uncorrected_col,
+                                          corrected_col=corrected_col, use_expr=use_expr)
         return self.with_step(step)
 
     def linefit(  # noqa: PLR0917

--- a/mass2/core/drift_correction.py
+++ b/mass2/core/drift_correction.py
@@ -150,7 +150,7 @@ class TimeDriftCorrectStep(RecipeStep):
         time_s, uncorrected_s = ch.good_serieses([time_col, uncorrected_col], use_expr)
         time_s2 = time_s - time_s[0]
         time_float_s = time_s2.dt.total_seconds(fractional=True)
-        pk = uncorrected_s.median()
+        pk = np.median(uncorrected_s.to_numpy())
         w = max(pk / 3000., 1.0)
 
         correction = mass2.core.analysis_algorithms.time_drift_correct(

--- a/mass2/core/drift_correction.py
+++ b/mass2/core/drift_correction.py
@@ -113,9 +113,15 @@ class TimeDriftCorrectStep(RecipeStep):
     def calc_from_df(self, df: pl.DataFrame) -> pl.DataFrame:
         """Apply the drift correction to the input DataFrame and return a new DataFrame with results."""
         time_col, uncorrected_col = self.inputs
+        time_s = df[time_col]
+        time_s2 = time_s - time_s[0]
+        time_float_s = time_s2.dt.total_seconds(fractional=True)
+        tnorm = self.correction["normalize"](time_float_s)
         model = self.correction["model"]
+        corrected_gain = 1 + model(tnorm)
+
         df2 = df.select(
-            pl.col(uncorrected_col) * model(pl.col(time_col)).alias(self.output[0])).with_columns(df)
+            (pl.col(uncorrected_col) * corrected_gain).alias(self.output[0])).with_columns(df)
         return df2
 
     def dbg_plot(self, df_after: pl.DataFrame, **kwargs: Any) -> plt.Axes:
@@ -140,10 +146,18 @@ class TimeDriftCorrectStep(RecipeStep):
         """Create a DriftCorrectStep by learning the correction from data in the given Channel."""
         if corrected_col is None:
             corrected_col = uncorrected_col + "_dc"
+
         time_s, uncorrected_s = ch.good_serieses([time_col, uncorrected_col], use_expr)
+        time_s2 = time_s - time_s[0]
+        time_float_s = time_s2.dt.total_seconds(fractional=True)
+        pk = uncorrected_s.median()
+        w = max(pk / 3000., 1.0)
+
         correction = mass2.core.analysis_algorithms.time_drift_correct(
-            time=time_s.to_numpy(),
+            time=time_float_s.to_numpy(),
             uncorrected=uncorrected_s.to_numpy(),
+            w=w,
+            limit=(0.5*pk, 1.5*pk),
             **kwargs
         )
         step = cls(

--- a/mass2/core/drift_correction.py
+++ b/mass2/core/drift_correction.py
@@ -102,3 +102,55 @@ class DriftCorrection:
         indicator = np.asarray(indicator)
         uncorrected = np.asarray(uncorrected)
         return uncorrected * (1 + (indicator - self.offset) * self.slope)
+
+
+@dataclass(frozen=True)
+class TimeDriftCorrectStep(RecipeStep):
+    """A RecipeStep to apply a drift correction to pulse data as a spline in time in a DataFrame."""
+
+    correction: typing.Any
+
+    def calc_from_df(self, df: pl.DataFrame) -> pl.DataFrame:
+        """Apply the drift correction to the input DataFrame and return a new DataFrame with results."""
+        time_col, uncorrected_col = self.inputs
+        model = self.correction["model"]
+        df2 = df.select(
+            pl.col(uncorrected_col) * model(pl.col(time_col)).alias(self.output[0])).with_columns(df)
+        return df2
+
+    def dbg_plot(self, df_after: pl.DataFrame, **kwargs: Any) -> plt.Axes:
+        """Plot the uncorrected and corrected values against the indicator for debugging purposes."""
+        indicator_col, uncorrected_col = self.inputs
+        # breakpoint()
+        df_small = df_after.lazy().filter(self.good_expr).filter(self.use_expr).select(self.inputs + self.output).collect()
+        mass2.misc.plot_a_vs_b_series(df_small[indicator_col], df_small[uncorrected_col])
+        mass2.misc.plot_a_vs_b_series(
+            df_small[indicator_col],
+            df_small[self.output[0]],
+            axis=plt.gca(),
+        )
+        plt.legend()
+        return plt.gca()
+
+    @classmethod
+    def learn(
+        cls, ch: "Channel", time_col: str, uncorrected_col: str,
+        corrected_col: str | None, use_expr: pl.Expr, **kwargs: Any
+    ) -> "TimeDriftCorrectStep":
+        """Create a DriftCorrectStep by learning the correction from data in the given Channel."""
+        if corrected_col is None:
+            corrected_col = uncorrected_col + "_dc"
+        time_s, uncorrected_s = ch.good_serieses([time_col, uncorrected_col], use_expr)
+        correction = mass2.core.analysis_algorithms.time_drift_correct(
+            time=time_s.to_numpy(),
+            uncorrected=uncorrected_s.to_numpy(),
+            **kwargs
+        )
+        step = cls(
+            inputs=[time_col, uncorrected_col],
+            output=[corrected_col],
+            good_expr=ch.good_expr,
+            use_expr=use_expr,
+            correction=correction,
+        )
+        return step

--- a/mass2/core/pulse_algorithms.py
+++ b/mass2/core/pulse_algorithms.py
@@ -190,7 +190,7 @@ def pulse_2exp_with_tail(
         # value at peak
         max_val = np.exp(-t_peak / tau_fall) - np.exp(-t_peak / tau_rise)
     else:  # tau_fall == tau_rise
-        max_val = 1 / np.e
+        max_val = np.exp(-1)
 
     return (
         a_tail * np.exp(-tt / tau_tail) / np.exp(-tt[0] / tau_tail)  # normalized tail

--- a/tests/core/test_channels.py
+++ b/tests/core/test_channels.py
@@ -535,7 +535,7 @@ def test_channel_mismatched_n_samples():
 
 
 def test_ch_from_numpy():
-    "Test that we can random values from a numpy file"
+    "Test that we can read random values from a numpy file"
     nsamp, npulses = 100, 60
     raw = np.random.default_rng().normal(10000, 1000, size=(nsamp, npulses)).astype(np.int16)
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Add code that makes it easy to use the classic mass algorithm `time_drift_correct`, to (attempt to) remove gain drifts that take place over hours-long time scales.