### PR TITLE
Use python `@` for dot products

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,7 @@
 
 **2.0.5** April 23, 2026-
 * Fix typo in Getting Started doc that can shadow `range` and screw up your iPython session (issue 137).
+* Use the clearer notation `A @ v` for matrix-vector, vector-vector, and similar dot products (issue 139).
 
 **2.0.4** April 14, 2026
 * Add `mass2.Channel.from_numpy()` to read optical TES raw data. Tests to go with it.

--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -86,7 +86,7 @@ def test_mass_5lag_filters(Maxsignal=100.0, sigma_noise=1.0, n=500):
 
     # Check filter's normalization
     f = filt_5lag.values
-    verify_close(Maxsignal, f.dot(truncated_signal), rtol=1e-5, topic="Filter normalization")
+    verify_close(Maxsignal, (f @ truncated_signal), rtol=1e-5, topic="Filter normalization")
 
     # Check filter's variance
     expected_dV = sigma_noise / n**0.5 * signal.max() / truncated_signal.std()

--- a/examples/__250804_Pu239_Co57_BLANK.py
+++ b/examples/__250804_Pu239_Co57_BLANK.py
@@ -218,7 +218,7 @@ def _(ch2, mass2, max_residual_rms, mo, np, npre, phi0_dac_units, pl):
             ch2.good_series("pulse", use_expr=True).limit(1000).to_numpy().mean(axis=0)
         )
         avg_pulse = avg_pulse - np.mean(avg_pulse)
-        template = avg_pulse / np.sqrt(np.dot(avg_pulse, avg_pulse))
+        template = avg_pulse / np.linalg.norm(avg_pulse)
         return template
 
 
@@ -227,7 +227,7 @@ def _(ch2, mass2, max_residual_rms, mo, np, npre, phi0_dac_units, pl):
 
     def residual_rms(pulse):
         pulse = pulse - np.mean(pulse)
-        dot = np.dot(pulse, template)
+        dot = pulse @ template
         pulse2 = dot * template
         residual = pulse2 - pulse
         return mass2.misc.root_mean_squared(residual)

--- a/examples/__250804_Pu239_Co57_am243_20um.py
+++ b/examples/__250804_Pu239_Co57_am243_20um.py
@@ -218,14 +218,14 @@ def _(ch2, mass2, max_residual_rms, mo, np, npre, phi0_dac_units, pl):
             ch2.good_series("pulse", use_expr=True).limit(1000).to_numpy().mean(axis=0)
         )
         avg_pulse = avg_pulse - np.mean(avg_pulse)
-        template = avg_pulse / np.sqrt(np.dot(avg_pulse, avg_pulse))
+        template = avg_pulse / np.linalg.norm(avg_pulse)
         return template
 
     template = make_template()
 
     def residual_rms(pulse):
         pulse = pulse - np.mean(pulse)
-        dot = np.dot(pulse, template)
+        dot = pulse @ template
         pulse2 = dot * template
         residual = pulse2 - pulse
         return mass2.misc.root_mean_squared(residual)

--- a/examples/__250804_Pu239_Co57_am243_weekend.py
+++ b/examples/__250804_Pu239_Co57_am243_weekend.py
@@ -220,14 +220,14 @@ def _(ch2, mass2, max_residual_rms, mo, np, npre, phi0_dac_units, pl):
             ch2.good_series("pulse", use_expr=True).limit(1000).to_numpy().mean(axis=0)
         )
         avg_pulse = avg_pulse - np.mean(avg_pulse)
-        template = avg_pulse / np.sqrt(np.dot(avg_pulse, avg_pulse))
+        template = avg_pulse / np.linalg.norm(avg_pulse)
         return template
 
     template = make_template()
 
     def residual_rms(pulse):
         pulse = pulse - np.mean(pulse)
-        dot = np.dot(pulse, template)
+        dot = pulse @ template
         pulse2 = dot * template
         residual = pulse2 - pulse
         return mass2.misc.root_mean_squared(residual)

--- a/examples/broken/240706_GDES001.py
+++ b/examples/broken/240706_GDES001.py
@@ -126,10 +126,10 @@ def _(
 def _(ch2, moss, np, pl):
     pulses = ch2.df["pulse"].to_numpy()
     avg_pulse = ch2.good_series("pulse", use_expr=True).limit(1000).to_numpy().mean(axis=0)
-    template = avg_pulse / np.sqrt(np.dot(avg_pulse, avg_pulse))
+    template = avg_pulse / np.linalg.norm(avg_pulse)
 
     def residual_rms(pulse, template):
-        dot = np.dot(pulse, template)
+        dot = pulse @ template
         pulse2 = dot * template
         residual = pulse2 - pulse
         return moss.misc.root_mean_squared(residual)

--- a/examples/broken/_240802_am243_weekend.py
+++ b/examples/broken/_240802_am243_weekend.py
@@ -196,11 +196,11 @@ def _(ch2, mo, moss, np, npre, pl):
     pulses = ch2.df["pulse"].to_numpy()
     avg_pulse = ch2.good_series("pulse", use_expr=True).limit(1000).to_numpy().mean(axis=0)
     avg_pulse = avg_pulse - np.mean(avg_pulse)
-    template = avg_pulse / np.sqrt(np.dot(avg_pulse, avg_pulse))
+    template = avg_pulse / np.linalg.norm(avg_pulse)
 
     def residual_rms(pulse):
         pulse = pulse - np.mean(pulse)
-        dot = np.dot(pulse, template)
+        dot = pulse @ template
         pulse2 = dot * template
         residual = pulse2 - pulse
         return moss.misc.root_mean_squared(residual)

--- a/examples/gamma_20241005.py
+++ b/examples/gamma_20241005.py
@@ -326,8 +326,8 @@ def _(data3, mass2, np, pl):
             "white_filt5lag": white_5lagy,
             "white_filt5lag_dc": white_5lagy_dc,
             "pulse_average390": pulses[:, npre:390].mean(axis=1) - pulses[:, :npre].mean(axis=1),
-            "fit_white": pulses.dot(filter2),
-            "fit_white_dpdt": pulses.dot(filter3),
+            "fit_white": (pulses @ filter2),
+            "fit_white_dpdt": (pulses @ filter3),
         })
         return ch.with_columns(new_df)
 

--- a/examples/npy_data_noise_limited_optical_tes.py
+++ b/examples/npy_data_noise_limited_optical_tes.py
@@ -117,7 +117,7 @@ def _(avg_pulse, np):
         unit_vec = avg_pulse / norm
 
         def get_residual_rms(pulse):
-            height = np.dot(pulse, unit_vec)
+            height = pulse @ unit_vec
             residuals = pulse - (height * unit_vec)
             return np.sqrt(np.mean(residuals**2))
 

--- a/mass2/calibration/hci_lines.py
+++ b/mass2/calibration/hci_lines.py
@@ -229,7 +229,7 @@ def add_hci_line(
     widths = np.asarray(widths)
     ratios = np.asarray(ratios)
     if nominal_peak_energy is None:
-        nominal_peak_energy = np.dot(energies, ratios) / np.sum(ratios)
+        nominal_peak_energy = (energies @ ratios) / np.sum(ratios)
     linetype = f"{int(spectr_ch)} {line_identifier}"
 
     spectrum_class = fluorescence_lines.addline(

--- a/mass2/core/analysis_algorithms.py
+++ b/mass2/core/analysis_algorithms.py
@@ -511,7 +511,7 @@ def time_drift_correct(  # noqa: PLR0914
         "The model function, with one parameter pi varied, others fixed."
         pcopy = np.array(param)
         pcopy[i] = param_i
-        return 1 + np.dot(basis.T, pcopy)
+        return 1 + pcopy @ basis
 
     def cost1(pi: NDArray, i: int, param: NDArray, y: NDArray, w: float, basis: NDArray) -> float:
         "The cost function (spectral entropy), with one parameter pi varied, others fixed."

--- a/mass2/core/optimal_filtering.py
+++ b/mass2/core/optimal_filtering.py
@@ -150,7 +150,7 @@ class ToeplitzWhitener:
         y[N - 1] /= self.phi[0]
         for i in range(N - 2, -1, -1):
             f = min(self.p + 1, N - i)
-            y[i] -= np.dot(y[i + 1 : i + f], self.phi[1:f])
+            y[i] -= y[i + 1 : i + f] @ self.phi[1:f]
             y[i] /= self.phi[0]
         return np.correlate(y, self.theta, "full")[self.q :]
 
@@ -170,7 +170,7 @@ class ToeplitzWhitener:
         y[N - 1] /= self.theta[0]
         for i in range(N - 2, -1, -1):
             f = min(self.q + 1, N - i)
-            y[i] -= np.dot(y[i + 1 : i + f], self.theta[1:f])
+            y[i] -= y[i + 1 : i + f] @ self.theta[1:f]
             y[i] /= self.theta[0]
         return np.correlate(y, self.phi, "full")[self.p :]
 
@@ -389,14 +389,14 @@ class Filter5Lag(Filter):
         nrec = x.shape[0]
         conv = np.zeros((nlags, nrec), dtype=float)
         for i in range(nlags - 1):
-            conv[i, :] = np.dot(x[:, i : i + 1 - nlags], self.values)
-        conv[nlags - 1, :] = np.dot(x[:, nlags - 1 :], self.values)
+            conv[i, :] = x[:, i : i + 1 - nlags] @ self.values
+        conv[nlags - 1, :] = x[:, nlags - 1 :] @ self.values
 
         # Least-squares fit of 5 values to a parabola.
         # Order is row 0 = constant ... row 2 = quadratic coefficients.
         if nlags != 5:
             raise NotImplementedError("Currently require 5 lags to estimate peak x, y")
-        param = np.dot(self.FIVELAG_FITTER, conv)
+        param = self.FIVELAG_FITTER @ conv
         peak_x = -0.5 * param[1, :] / param[2, :]
         peak_y = param[0, :] - 0.25 * param[1, :] ** 2 / param[2, :]
         return peak_y, peak_x
@@ -450,7 +450,7 @@ class Filter1Lag(Filter):
             x = x.reshape((1, len(x)))
         _, nsamp = x.shape
         assert nsamp == len(self.values)
-        dotproduct = np.dot(x, self.values)
+        dotproduct = x @ self.values
 
         peak_x = np.zeros_like(x)
         peak_y = dotproduct
@@ -514,8 +514,8 @@ class FilterATS(Filter):
 def _filter_records_ats(x: NDArray, values: NDArray, dt_values: NDArray) -> tuple[np.ndarray, np.ndarray]:
     "A numba-JIT speedup of the core computation"
     x = x.astype(values.dtype)
-    conv0 = np.dot(x, values)
-    conv1 = np.dot(x, dt_values)
+    conv0 = x @ values
+    conv1 = x @ dt_values
     arrival_time = conv1 / conv0
     return conv0, arrival_time
 
@@ -643,7 +643,7 @@ class FilterMaker:
         noise_corr = noise_autocorr[:n]
         TS = ToeplitzSolver(noise_corr, symmetric=True)
         Rinv_model = np.vstack([TS(r) for r in pulse_model])
-        A = pulse_model.dot(Rinv_model.T)
+        A = pulse_model @ (Rinv_model.T)
         all_filters = np.linalg.solve(A, Rinv_model)
         filt_noconst = all_filters[0]
 
@@ -768,7 +768,7 @@ class FilterMaker:
         noise_corr = noise_autocorr[:n]
         TS = ToeplitzSolver(noise_corr, symmetric=True)
         Rinv_model = np.vstack([TS(r) for r in pulse_model])
-        A = pulse_model.dot(Rinv_model.T)
+        A = pulse_model @ (Rinv_model.T)
         all_filters = np.linalg.solve(A, Rinv_model)
         filt_noconst = all_filters[0]
 
@@ -1018,10 +1018,10 @@ class FilterMaker:
 
         if self.whitener is not None:
             WM = self.whitener(MT.T)
-            A = np.dot(WM.T, WM)
+            A = WM.T @ WM
             Ainv = np.linalg.inv(A)
             WtWM = self.whitener.applyWT(WM)
-            filt = np.dot(Ainv, WtWM.T)
+            filt = Ainv @ (WtWM.T)
 
         else:
             assert len(noise_autocorr) >= ns
@@ -1029,9 +1029,9 @@ class FilterMaker:
             TS = ToeplitzSolver(noise_corr, symmetric=True)
 
             RinvM = np.vstack([TS(r) for r in MT]).T
-            A = np.dot(MT, RinvM)
+            A = MT @ RinvM
             Ainv = np.linalg.inv(A)
-            filt = np.dot(Ainv, RinvM.T)
+            filt = Ainv @ (RinvM.T)
 
         band_limit(filt.T, self.sample_time_sec, fmax, f_3db)
 
@@ -1155,7 +1155,7 @@ class FilterMaker:
         assert len(f) <= len(avg_signal) - 4
         conv = np.zeros(5, dtype=float)
         for i in range(5):
-            conv[i] = np.dot(f, avg_signal[i : i + len(f)])
+            conv[i] = f @ avg_signal[i : i + len(f)]
         x = np.linspace(-2, 2, 5)
         fit = np.polyfit(x, conv, 2)
         fit_ctr = -0.5 * fit[1] / fit[0]
@@ -1174,7 +1174,7 @@ class FilterMaker:
             The signal to which filter `f` should give unit response
         """
         assert len(f) == len(avg_signal)
-        f *= 1 / np.dot(f, avg_signal)
+        f *= 1 / (f @ avg_signal)
 
 
 def bracketR(q: NDArray, noise: NDArray) -> float:
@@ -1192,5 +1192,5 @@ def bracketR(q: NDArray, noise: NDArray) -> float:
     r[n - 1 :: -1] = noise[:n]
     dot = 0.0
     for i in range(n):
-        dot += q[i] * r[n - i - 1 : 2 * n - i - 1].dot(q)
+        dot += q[i] * r[n - i - 1 : 2 * n - i - 1] @ q
     return dot

--- a/mass2/core/optimal_filtering.py
+++ b/mass2/core/optimal_filtering.py
@@ -1192,5 +1192,6 @@ def bracketR(q: NDArray, noise: NDArray) -> float:
     r[n - 1 :: -1] = noise[:n]
     dot = 0.0
     for i in range(n):
-        dot += q[i] * r[n - i - 1 : 2 * n - i - 1] @ q
+        row_i = r[n - i - 1 : 2 * n - i - 1]
+        dot += q[i] * (row_i @ q)
     return dot

--- a/mass2/core/pulse_model.py
+++ b/mass2/core/pulse_model.py
@@ -12,7 +12,7 @@ from mass2.mathstat.utilities import find_range_randomly
 
 class PulseModel:
     """Object to hold a "pulse model", meaning a low-dimensional linear basis to express "all" pulses,
-    along with a projector such that projector.dot(basis) is the identity matrix.
+    along with a projector such that (projector @ basis) is the identity matrix.
 
     Also has the capacity to store to and restore from HDF5, and the ability to compute additional
     basis elements and corresponding projectors with method _additional_projectors_tsvd"""
@@ -140,7 +140,7 @@ class PulseModel:
         """
         Given an existing basis with projectors, compute a basis with n_basis elements
         by randomized SVD of the residual elements of the training data in pulses_for_svd.
-        It should be the case that projectors.dot(basis) is approximately the identity matrix.
+        It should be the case that (projectors @ basis) is approximately the identity matrix.
 
         It is assumed that the projectors will have been computed from the basis in some
         noise-optimal way, say, from optimal filtering. However, the additional basis elements

--- a/mass2/core/pulse_model.py
+++ b/mass2/core/pulse_model.py
@@ -6,8 +6,8 @@ from numpy.typing import NDArray
 import pylab as plt
 import numpy as np
 import h5py
-import mass2
 from mass2.common import tostr
+from mass2.mathstat.utilities import find_range_randomly
 
 
 class PulseModel:
@@ -161,10 +161,10 @@ class PulseModel:
         mpc = np.matmul(projectors, pulses_for_svd)  # modeled pulse coefs
         mp = np.matmul(basis, mpc)  # modeled pulse
         residuals = pulses_for_svd - mp
-        Q = mass2.mathstat.utilities.find_range_randomly(residuals, n_basis - n_existing)
+        Q = find_range_randomly(residuals, n_basis - n_existing)
 
         projectors2 = np.linalg.pinv(Q)  # = Q.T, perhaps??
-        projectors2 -= projectors2.dot(basis).dot(projectors)
+        projectors2 -= (projectors2 @ basis) @ projectors
 
         basis = np.hstack([basis, Q])
         projectors = np.vstack([projectors, projectors2])

--- a/mass2/core/truebq_bin.py
+++ b/mass2/core/truebq_bin.py
@@ -81,8 +81,7 @@ class TriggerResult:
 
         # trigger indices (raw) → restrict to plotted window → convert to decimated indices
         trig_inds_raw = (
-            pl
-            .DataFrame({"trig_inds": self.trig_inds})
+            pl.DataFrame({"trig_inds": self.trig_inds})
             .filter(pl.col("trig_inds").is_between(raw_start, raw_stop))
             .to_series()
             .to_numpy()
@@ -413,11 +412,11 @@ def fasttrig_filter_trigger(data: NDArray, filter_in: NDArray, threshold: float,
     # intitalize a,b,c
     j = 0
     cache[:] = data[j : (j + filter_len)]
-    b = np.dot(cache, filter)
+    b = cache @ filter
     a = b  # won't be used, just need same type
     j = 1
     cache[:] = data[j : (j + filter_len)]
-    c = np.dot(cache, filter)
+    c = cache @ filter
     j = 2
     ready = False
     prog_step = jmax // 100
@@ -429,7 +428,7 @@ def fasttrig_filter_trigger(data: NDArray, filter_in: NDArray, threshold: float,
                 print(f"fasttrig_filter_trigger {prog_ticks}/{100}")
         a, b = b, c
         cache[:] = data[j : (j + filter_len)]
-        c = np.dot(cache, filter)
+        c = cache @ filter
         if b > threshold and b >= c and b > a and ready:
             inds.append(j)
             ready = False
@@ -510,13 +509,13 @@ def filter_and_residual_rms(
     residual_rms = np.zeros(len(trig_inds))
     filt_value_template = np.zeros(len(trig_inds))
     template = avg_pulse - np.mean(avg_pulse)
-    template /= np.sqrt(np.dot(template, template))
+    template /= np.linalg.norm(template)
     for i in range(len(trig_inds)):
         j = trig_inds[i]
         pulse = data[j - npre : j + nsamples - npre] * polarity
         pulse -= pulse.mean()
-        filt_value[i] = np.dot(chosen_filter, pulse)
-        filt_value_template[i] = np.dot(template, pulse)
+        filt_value[i] = chosen_filter @ pulse
+        filt_value_template[i] = template @ pulse
         residual = pulse - template * filt_value_template[i]
         residual_rms_val = misc.root_mean_squared(residual)
         residual_rms[i] = residual_rms_val
@@ -535,7 +534,7 @@ def fast_apply_filter(data: NDArray, filter_in: NDArray) -> NDArray:
     jmax = len(data) - filter_len - 1
     while j <= jmax:
         cache[:] = data[j : (j + filter_len)]
-        filter_out[j] = np.dot(cache, filter)
+        filter_out[j] = cache @ filter
         j += 1
     return filter_out
 

--- a/mass2/mathstat/interpolate.py
+++ b/mass2/mathstat/interpolate.py
@@ -293,7 +293,8 @@ class GPRSpline(CubicSpline):
         # Compute at test points = self.x
         # We know that these are the knots of a natural cubic spline
         R = H - KinvHT.T @ K
-        fbar = np.dot(y, np.linalg.solve(L.T, np.linalg.solve(L, K)))
+        KyinvK = np.linalg.solve(L.T, np.linalg.solve(L, K))
+        fbar = self.y @ KyinvK
         gbar = fbar + R.T @ beta
         CubicSpline.__init__(self, self.x, gbar)
 
@@ -331,7 +332,8 @@ class GPRSpline(CubicSpline):
         LH = np.linalg.solve(L, H.T)
         A = LH.T @ LH
         KinvHT = np.linalg.solve(L.T, LH)
-        C = KinvHT.dot(np.linalg.solve(A, KinvHT.T))
+        result1 = np.linalg.solve(A, KinvHT.T)
+        C = KinvHT @ result1
         yCy = self.y @ (C @ self.y)
         Linvy = np.linalg.solve(L, self.y)
         yKinvy = Linvy @ Linvy
@@ -349,7 +351,8 @@ class GPRSpline(CubicSpline):
             LinvKtest = np.linalg.solve(self.L, Ktest)
             cov_ftest = self.sigmaf**2 * k_spline(x, x) - (LinvKtest**2).sum()
             R = np.array((1, x)) - self.KinvHT.T @ Ktest
-            v.append(cov_ftest + R.dot(np.linalg.solve(self.A, R)))
+            result1 = np.linalg.solve(self.A, R)
+            v.append(cov_ftest + R @ result1)
         if np.isscalar(xtest):
             return v[0]
         return np.array(v)
@@ -366,7 +369,8 @@ class GPRSpline(CubicSpline):
         cov_ftest -= LinvKtest.T @ LinvKtest
         R = np.vstack((np.ones(len(xtest)), xtest))
         R -= self.KinvHT.T @ Ktest
-        return cov_ftest + R.T.dot(np.linalg.solve(self.A, R))
+        result1 = np.linalg.solve(self.A, R)
+        return cov_ftest + R.T @ result1
 
 
 class NaturalBsplineBasis:

--- a/mass2/mathstat/interpolate.py
+++ b/mass2/mathstat/interpolate.py
@@ -283,18 +283,18 @@ class GPRSpline(CubicSpline):
         Ky = K + np.diag(self.err**2)
         L = np.linalg.cholesky(Ky)
         LH = np.linalg.solve(L, H.T)
-        A = LH.T.dot(LH)
+        A = LH.T @ LH
         KinvHT = np.linalg.solve(L.T, LH)
         self.L = L
         self.A = A
         self.KinvHT = KinvHT
-        beta = np.linalg.solve(A, KinvHT.T).dot(self.y)
+        beta = np.linalg.solve(A, KinvHT.T) @ self.y
 
         # Compute at test points = self.x
         # We know that these are the knots of a natural cubic spline
-        R = H - KinvHT.T.dot(K)
-        fbar = np.linalg.solve(L.T, np.linalg.solve(L, K)).T.dot(y)
-        gbar = fbar + R.T.dot(beta)
+        R = H - KinvHT.T @ K
+        fbar = np.dot(y, np.linalg.solve(L.T, np.linalg.solve(L, K)))
+        gbar = fbar + R.T @ beta
         CubicSpline.__init__(self, self.x, gbar)
 
     def best_sigmaf(self) -> float:
@@ -329,12 +329,12 @@ class GPRSpline(CubicSpline):
         Ky = K + np.diag(self.err**2)
         L = np.linalg.cholesky(Ky)
         LH = np.linalg.solve(L, H.T)
-        A = LH.T.dot(LH)
+        A = LH.T @ LH
         KinvHT = np.linalg.solve(L.T, LH)
         C = KinvHT.dot(np.linalg.solve(A, KinvHT.T))
-        yCy = self.y.dot(C.dot(self.y))
+        yCy = self.y @ (C @ self.y)
         Linvy = np.linalg.solve(L, self.y)
-        yKinvy = Linvy.dot(Linvy)
+        yKinvy = Linvy @ Linvy
         return -0.5 * ((self.Nk - 2) * np.log(2 * np.pi) + np.linalg.slogdet(A)[1] + np.linalg.slogdet(Ky)[1] - yCy + yKinvy)
 
     def variance(self, xtest: ArrayLike) -> NDArray:
@@ -348,7 +348,7 @@ class GPRSpline(CubicSpline):
             Ktest = self.sigmaf**2 * k_spline(x, self.x)
             LinvKtest = np.linalg.solve(self.L, Ktest)
             cov_ftest = self.sigmaf**2 * k_spline(x, x) - (LinvKtest**2).sum()
-            R = np.array((1, x)) - self.KinvHT.T.dot(Ktest)
+            R = np.array((1, x)) - self.KinvHT.T @ Ktest
             v.append(cov_ftest + R.dot(np.linalg.solve(self.A, R)))
         if np.isscalar(xtest):
             return v[0]
@@ -363,9 +363,9 @@ class GPRSpline(CubicSpline):
         Ktest = self.sigmaf**2 * np.vstack([k_spline(x, self.x) for x in xtest]).T
         LinvKtest = np.linalg.solve(self.L, Ktest)
         cov_ftest = self.sigmaf**2 * np.vstack([k_spline(x, xtest) for x in xtest])
-        cov_ftest -= LinvKtest.T.dot(LinvKtest)
+        cov_ftest -= LinvKtest.T @ LinvKtest
         R = np.vstack((np.ones(len(xtest)), xtest))
-        R -= self.KinvHT.T.dot(Ktest)
+        R -= self.KinvHT.T @ Ktest
         return cov_ftest + R.T.dot(np.linalg.solve(self.A, R))
 
 
@@ -542,8 +542,8 @@ class SmoothingSpline:
 
         Dinv = self.err ** (-2)  # Vector but stands for diagonals of a diagonal matrix.
         NTDinv = self.N0.T * Dinv
-        lhs = np.dot(NTDinv, self.N0)
-        rhs = np.dot(self.N0.T, Dinv * self.y)
+        lhs = NTDinv @ self.N0
+        rhs = self.N0.T @ (Dinv * self.y)
 
         def best_params(p: NDArray) -> NDArray:
             """Return the best-fit parameters for a given curvature penalty p."""
@@ -558,7 +558,7 @@ class SmoothingSpline:
                 beta = best_params(p)
             except np.linalg.LinAlgError:
                 return 1e99
-            ys = np.dot(self.N0, beta)
+            ys = self.N0 @ beta
             chisq = np.sum(((self.y - ys) / self.err) ** 2)
             return chisq - target_chisq
 
@@ -566,7 +566,7 @@ class SmoothingSpline:
         pbest = sp.optimize.brentq(chisq_difference, mincurvature, 1, args=(chisq,))
         beta = best_params(pbest)
         self.coeff = self.basis.expand_coeff(beta)
-        ys = np.dot(self.N0, beta)
+        ys = self.N0 @ beta
         self.actualchisq = np.sum(((self.y - ys) / self.err) ** 2)
 
         # Store the linear extrapolation outside the knotted region.

--- a/mass2/mathstat/toeplitz.py
+++ b/mass2/mathstat/toeplitz.py
@@ -93,10 +93,10 @@ class ToeplitzSolver:
         N = len(x)
         assert N == self.n
         y = np.zeros_like(x)
-        y[0] = np.dot(self.T, x)
+        y[0] = self.T @ x
         for i in range(1, N):
-            y[i] = np.dot(self.T[:-i], x[i:])
-            y[i] += np.dot(self.T[1 : 1 + i], x[i - 1 :: -1])
+            y[i] = self.T[:-i] @ x[i:]
+            y[i] += self.T[1 : 1 + i] @ x[i - 1 :: -1]
         return y
 
     def __call__(self, y: ArrayLike) -> np.ndarray:

--- a/mass2/mathstat/utilities.py
+++ b/mass2/mathstat/utilities.py
@@ -106,10 +106,9 @@ def find_range_randomly(A: ArrayLike, nl: int, q: int = 1) -> NDArray:
     A = np.asarray(A)
     _m, n = A.shape
     Omega = rng.standard_normal((n, nl))
-    Y = np.dot(A, Omega)
+    Y = A @ Omega
     for _ in range(q):
-        Y = np.dot(A.T, Y)
-        Y = np.dot(A, Y)
+        Y = A @ (A.T @ Y)
     Q, _R = np.linalg.qr(Y)
     return Q
 
@@ -124,7 +123,7 @@ def find_svd_randomly(A: ArrayLike, nl: int, q: int = 2) -> tuple[NDArray, NDArr
     """
     A = np.asarray(A)
     Q = find_range_randomly(A, nl, q=q)
-    B = np.dot(Q.T, A)
+    B = Q.T @ A
     SVD_B = np.linalg.svd(B, full_matrices=False)
-    u = np.dot(Q, SVD_B.U)
+    u = Q @ SVD_B.U
     return SVD_B._replace(U=u)

--- a/tests/core/test_filtering.py
+++ b/tests/core/test_filtering.py
@@ -157,7 +157,7 @@ def test_constrained_filtering():  # noqa: PLR0914
     f_constrained = maker.compute_constrained_5lag(constraints)
     for i, vec in enumerate(constraints):
         msg2 = f"compute_constrained_5lag filter values are not orthogonal to constraint # {i}"
-        assert np.abs(f_constrained.values.dot(vec)) < 1e-9, msg2
+        assert np.abs(f_constrained.values @ vec) < 1e-9, msg2
 
 
 def test_no_concrete_baseFilter():

--- a/tests/mathstat/test_power_spectrum.py
+++ b/tests/mathstat/test_power_spectrum.py
@@ -60,4 +60,4 @@ def test_creating_filter_from_non_LJH_data():
     print("predicted resolutions")
     filter_obj.report(std_energy=1000)
     chosen_filter = filter_obj.values
-    np.dot(chosen_filter, avg_pulse_values[2:-2])
+    _ = chosen_filter @ avg_pulse_values[2:-2]

--- a/tests/mathstat/test_toeplitz.py
+++ b/tests/mathstat/test_toeplitz.py
@@ -32,7 +32,7 @@ class TestToeplitzSolverSmallSymmetric:
         for i in range(self.n):
             x_in = np.zeros(self.n, dtype=float)
             x_in[i] = 1.0
-            y = np.dot(self.R, x_in)
+            y = self.R @ x_in
             x_out = self.solver(y)
             big_dif = np.abs(x_out - x_in).max()
             assert 0 == pytest.approx(big_dif, abs=1e-12)
@@ -40,7 +40,7 @@ class TestToeplitzSolverSmallSymmetric:
     def test_arb_vectors(self):
         for _i in range(self.n):
             x_in = 5 * rng.standard_normal(self.n)
-            y = np.dot(self.R, x_in)
+            y = self.R @ x_in
             x_out = self.solver(y)
             big_dif = np.abs(x_out - x_in).max()
             assert 0 == pytest.approx(big_dif, abs=1e-12)
@@ -59,7 +59,7 @@ class TestToeplitzSolverSmallAsymmetric:
         for i in range(self.n):
             x_in = np.zeros(self.n, dtype=float)
             x_in[i] = 1.0
-            y = np.dot(self.R, x_in)
+            y = self.R @ x_in
             x_out = self.solver(y)
             big_dif = np.abs(x_out - x_in).max()
             assert 0 == pytest.approx(big_dif, abs=1e-12)
@@ -67,7 +67,7 @@ class TestToeplitzSolverSmallAsymmetric:
     def test_arb_vectors(self):
         for _i in range(self.n):
             x_in = 5 * rng.standard_normal(self.n)
-            y = np.dot(self.R, x_in)
+            y = self.R @ x_in
             x_out = self.solver(y)
             big_dif = np.abs(x_out - x_in).max()
             assert 0 == pytest.approx(big_dif, abs=1e-12)
@@ -92,7 +92,7 @@ class TestToeplitzSolver_32:
         for i in range(self.n):
             x_in = np.zeros(self.n, dtype=float)
             x_in[i] = 1.0
-            y = np.dot(self.R, x_in)
+            y = self.R @ x_in
             x_out = self.solver(y)
             big_dif = np.abs(x_out - x_in).max()
             assert 0 == pytest.approx(big_dif, abs=1e-10), f"Unit vector trial i={i:2d} gives x_out={x_out}"
@@ -113,7 +113,7 @@ class TestToeplitzSolver_512:
         for i in (0, 20, 128, 256, 500, 512 - 1):
             x_in = np.zeros(self.n, dtype=float)
             x_in[i] = 1.0
-            y = np.dot(self.R, x_in)
+            y = self.R @ x_in
             x_out = self.solver(y)
             big_dif = np.abs(x_out - x_in).max()
             assert 0 == pytest.approx(big_dif, abs=1e-10), f"Unit vector trial i={i:2d} gives x_out={x_out}"
@@ -121,7 +121,7 @@ class TestToeplitzSolver_512:
     def test_arb_vectors(self):
         for _i in range(5):
             x_in = 5 * rng.standard_normal(self.n)
-            y = np.dot(self.R, x_in)
+            y = self.R @ x_in
             x_out = self.solver(y)
             big_dif = np.abs(x_out - x_in).max()
             assert 0 == pytest.approx(big_dif, abs=1e-10), f"Random vector trial gives rms diff={(x_out - x_in).std()}"
@@ -172,7 +172,7 @@ class toeplitzSpeed:
 
             # dt[2] = R * vector time
             t0 = time.time()
-            v2 = np.dot(R, x)
+            v2 = R @ x
             dt.append(time.time() - t0)
 
             # dt[3] = solve(R,v) time


### PR DESCRIPTION
Use the syntax now 11 years old to write matrix-vector, vector-vector, matrix-matrix, and vector-matrix dot products as `M @ v`, `v1 @ v2`, `A @ B`, and `v @ A`. The latter is equivalent to `A.T @ v`. 

This is easier to read and apparently preferred. See [`numpy.dot` documentation](https://numpy.org/doc/stable/reference/generated/numpy.dot.html). I'm not sure how I just learned about this last week.

Also use `np.linalg.norm(v)` for clarity, instead of `np.sqrt((v**2).sum())` or `np.sqrt(np.dot(v, v))`
See #139.