### PR TITLE
Add Nb Ge K lines

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -6,6 +6,7 @@
 * Fix typo in Getting Started doc that can shadow `range` and screw up your iPython session (issue 137).
 * Use the clearer notation `A @ v` for matrix-vector, vector-vector, and similar dot products (issue 139).
 * Add Generalized Column Subset Selection (issue 140).
+* Add Ge and Nb K-alpha and K-beta line models (issue 145).
 
 **2.0.4** April 14, 2026
 * Add `mass2.Channel.from_numpy()` to read optical TES raw data. Tests to go with it.

--- a/docs/line_fitting.md
+++ b/docs/line_fitting.md
@@ -76,8 +76,8 @@ resultA = model.fit(sim, params, bin_centers=e)
 # This will not work for nearly monochromatic lines, however, as the resolution (fwhm) and scale (dph_de) are exactly degenerate.
 # In practice, most fits are done with dph_de fixed.
 params = resultA.params.copy()
-resultB = model.fit(sim, params, bin_centers=e, dph_de=1)
 params["dph_de"].set(1.0, vary=False)
+resultB = model.fit(sim, params, bin_centers=e, dph_de=1)
 
 # There are two plotting methods. The first is an LMfit built-in; the other ("mass-style") puts the
 # fit parameters on the plot.

--- a/mass2/calibration/fluorescence_lines.py
+++ b/mass2/calibration/fluorescence_lines.py
@@ -1061,6 +1061,35 @@ addline(
 )
 
 addline(
+    element="Ge",
+    material="metal",
+    linetype="KAlpha",
+    reference_short="Zschornack",
+    reference_plot_instrument_gaussian_fwhm=0.17,
+    nominal_peak_energy=9886.52,
+    energies=np.array((9886.52, 9855.42)),
+    lorentzian_fwhm=np.array((2.8, 2.9)),
+    reference_amplitude=np.array((0.600, 0.309)),
+    ka12_energy_diff=31.10,
+    reference_amplitude_type=AmplitudeType.LORENTZIAN_INTEGRAL_INTENSITY,
+)
+
+
+addline(
+    element="Ge",
+    material="metal",
+    linetype="KBeta",
+    reference_short="Zschornack",
+    reference_plot_instrument_gaussian_fwhm=0.17,
+    nominal_peak_energy=10982.19,
+    energies=np.array((10982.19, 10978.1)),
+    lorentzian_fwhm=np.array((5.56, 5.84)),
+    reference_amplitude=np.array((8.62, 4.40)),
+    reference_amplitude_type=AmplitudeType.LORENTZIAN_INTEGRAL_INTENSITY,
+)
+
+
+addline(
     element="Se",
     material="metal",
     linetype="KAlpha",
@@ -1160,6 +1189,35 @@ addline(
     # We estimate 17680 by reading Figure 2.
     lorentzian_fwhm=np.array((6.171, 5.89, 10.8)),
     reference_amplitude=np.array((100, 50.49, 5.2)),
+    reference_amplitude_type=AmplitudeType.LORENTZIAN_INTEGRAL_INTENSITY,
+)
+
+
+addline(
+    element="Nb",
+    material="metal",
+    linetype="KAlpha",
+    reference_short="Zschornack",
+    reference_plot_instrument_gaussian_fwhm=0.17,
+    nominal_peak_energy=16615.16,
+    energies=np.array((16615.16, 16521.28)),
+    lorentzian_fwhm=np.array((5.80, 6.01)),
+    reference_amplitude=np.array((1.669, 0.874)),
+    ka12_energy_diff=93.9,
+    reference_amplitude_type=AmplitudeType.LORENTZIAN_INTEGRAL_INTENSITY,
+)
+
+
+addline(
+    element="Nb",
+    material="metal",
+    linetype="KBeta",
+    reference_short="Zschornack",
+    reference_plot_instrument_gaussian_fwhm=0.17,
+    nominal_peak_energy=18622.68,
+    energies=np.array((18622.68, 18606.5)),
+    lorentzian_fwhm=np.array((6.95, 6.81)),
+    reference_amplitude=np.array((0.2607, 0.1339)),
     reference_amplitude_type=AmplitudeType.LORENTZIAN_INTEGRAL_INTENSITY,
 )
 

--- a/mass2/data/fluorescence_line_references.yaml
+++ b/mass2/data/fluorescence_line_references.yaml
@@ -147,7 +147,7 @@
   URL: https://doi.org/10.1103/PhysRevB.97.125139
 
 - tag: Rough Estimate
-  description: Line energies from the stanard database, relative intensities and widths are guesses.
+  description: Line energies from the standard database, relative intensities and widths are guesses.
 
 - tag: Schweppe 1992 Al
   description: |
@@ -179,4 +179,7 @@
     The KBeta also appears to be a hack with scaled values.
 
 - tag: Zschornack
-  description: Zschornack, Günter H. (2007). Handbook of X-Ray Data. Springer-Verlag, Berlin.
+  description: |
+    Zschornack, Günter H. (2007). Handbook of X-Ray Data. Springer-Verlag, Berlin.
+    This text does not contain full line shapes, but just line energies, widths, and
+    relative intensities. Any line model based on this reference is an approximation.


### PR DESCRIPTION
Fixes #145. Adds the K-alpha doublet and a 2-component K-beta line for Ge and Nb. The TKID team needs these to fit for energy resolution.

These are based on figures found in Zschornack (2007), and not on modern, high-resolution metrological data.