### PR TITLE
Improve user experience

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -7,6 +7,7 @@
 * Several small quality-of-life changes (issue 139):
   * Use the clearer notation `A @ v` for matrix-vector, vector-vector, and similar dot products.
   * Use an API for `Channel.with_columns()` like that of `pl.DataFrame` to match user expectations.
+  * Add method `combine_channels(sourcename, dict)` to `Channel` and `Channels`.
 * Add Generalized Column Subset Selection (issue 140).
 * Add Kα and Kβ line models for Ge and Nb based on Zschornack book (issue 145).
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,9 +4,11 @@
 
 **2.0.5** April 23, 2026-
 * Fix typo in Getting Started doc that can shadow `range` and screw up your iPython session (issue 137).
-* Use the clearer notation `A @ v` for matrix-vector, vector-vector, and similar dot products (issue 139).
+* Several small quality-of-life changes (issue 139):
+  * Use the clearer notation `A @ v` for matrix-vector, vector-vector, and similar dot products.
+  * Use an API for `Channel.with_columns()` like that of `pl.DataFrame` to match user expectations.
 * Add Generalized Column Subset Selection (issue 140).
-* Add Ge and Nb K-alpha and K-beta line models (issue 145).
+* Add Kα and Kβ line models for Ge and Nb based on Zschornack book (issue 145).
 
 **2.0.4** April 14, 2026
 * Add `mass2.Channel.from_numpy()` to read optical TES raw data. Tests to go with it.
@@ -405,7 +407,7 @@
 
 **0.4.4** August 2016
 
-* Young changed the version number, but I (JF) do not know why.
+* Young changed the revision number, but I (JF) do not know why.
 
 **0.4.3** May 2016
 

--- a/examples/broken/pax_20250428.py
+++ b/examples/broken/pax_20250428.py
@@ -63,7 +63,7 @@ def _(data, mass2, np, pl):
         )
         ptm1 = ch.df["pretrig_mean"].to_numpy()
         ptm2 = np.unwrap(ptm1 % 4096, period=4096)
-        ch = ch.with_columns(pl.DataFrame({"ptm2": ptm2}))
+        ch = ch.with_columns(ptm2=ptm2)
         return ch
 
     data2 = data.map(_do_analysis)

--- a/mass2/common.py
+++ b/mass2/common.py
@@ -1,7 +1,7 @@
 """
 common.py
 
-Stand-along functions that can be used throughout MASS.
+Stand-alone functions that can be used throughout MASS.
 """
 
 import six

--- a/mass2/core/channel.py
+++ b/mass2/core/channel.py
@@ -1556,6 +1556,10 @@ class Channel:
         holding the data from all 5 objects, plus a new column named "element", which will be one of
         {"Be", "Fe", "Ge", "Se", "Xe"}, according to which LJH file it came from.
 
+        BEWARE: this will entail a copy of all raw data in all input LJH files, as far as we know.
+        That's a memory-intensive request. Use for small files only, or for `Channel` objects that are
+        no longer connected directly to raw pulse files!
+
         Parameters
         ----------
         sourcename : str

--- a/mass2/core/channel.py
+++ b/mass2/core/channel.py
@@ -1617,10 +1617,18 @@ class Channel:
         df = self.df.drop(*args)
         return self.with_replacement_df(df)
 
-    def with_columns(self, df2: pl.DataFrame) -> "Channel":
-        """Append columns from df2 to the existing dataframe, keeping all other attributes the same."""
-        df3 = self.df.with_columns(df2)
-        return self.with_replacement_df(df3)
+    def with_columns(self, *exprs: pl.Expr | Iterable[pl.Expr] | pl.DataFrame, **named_exprs: pl.Expr) -> "Channel":
+        """Append expressions from *exprs or **named_exprs to the existing dataframe, preserving all other attributes.
+
+        Possible uses include:
+        1. ch.with_columns(pl.col("oldcolumn").sqrt().alias("newsqrt"), ... )
+        2. ch.with_columns(newsqrt=pl.col("oldcolumn").sqrt())
+        3. Two steps: construct a pl.DataFrame from a dict first
+            df = {"newsqrt": pl.col("oldcolumn").sqrt()}
+            ch.with_columns(df)
+        """
+        enhanced_df = self.df.with_columns(*exprs, **named_exprs)
+        return self.with_replacement_df(enhanced_df)
 
     def multifit_quadratic_gain_cal(
         self,
@@ -1742,8 +1750,10 @@ class Channel:
         downsample = max(downsample, 1)
 
         df = self.df.lazy().gather_every(downsample)
-        df = df.with_columns(((pl.col("peak_index") - self.n_presamples) * (1e6 * self.frametime_s)).alias("peak_time_µs"))
-        df = df.with_columns((pl.col("rise_time") * 1e6).alias("rise_time_µs"))
+        df = df.with_columns(
+            ((pl.col("peak_index") - self.n_presamples) * (1e6 * self.frametime_s)).alias("peak_time_µs"),
+            (pl.col("rise_time") * 1e6).alias("rise_time_µs"),
+        )
         existing_columns = df.collect_schema().names()
         preserve = [p[0] for p in plottables if p[0] in existing_columns]
         preserve.append("timestamp")

--- a/mass2/core/channel.py
+++ b/mass2/core/channel.py
@@ -144,7 +144,7 @@ class Channel:
         return replace(self, df=df, npulses=len(df))
 
     def sample(self, n: int | None, fraction: float | None = None) -> "Channel":
-        "Return a new Channel, using only the last `n` pulse records (or if n<0, then all but the first abs(n))."
+        "Return a new Channel, using only a random selection of `n` pulse records."
         df = self.df.sample(n=n, fraction=fraction, with_replacement=False)
         return replace(self, df=df, npulses=len(df))
 
@@ -1528,6 +1528,57 @@ class Channel:
         source = os.path.basename(pulse_fname)
         header = ChannelHeader(description, source, ch_num, frametime_s, n_presamples=npresamples, n_samples=nsamples, df=pulse_df)
         return cls(pulse_df, header, npulses, noise=nch)
+
+    @classmethod
+    def combine_channels(cls, sourcename: str, constituents: dict[str, "Channel"]) -> "Channel":
+        """Combine 2 or more channels into 1 (they presumably correspond to one microcalorimeter used
+        under different, discrete conditions). Add a new column to the combined channel's dataframe that
+        tracks their names (i.e, their keys in the dictionary `constituents`). The constituents must have
+        equal `n_samples`, `n_presamples`, and `frametime_s`. Any other incompatibility is used at your own
+        risk.
+
+        The first entry in `constituents` will govern the good expression and history of steps. For this reason,
+        it is best to combine channel objects before any receipe steps are performed.
+
+        Example:
+        ----------
+        >>> constituents = {
+        ...     "Be": mass2.Channel.from_ljh(pathBe),
+        ...     "Fe": mass2.Channel.from_ljh(pathFe),
+        ...     "Ge": mass2.Channel.from_ljh(pathGe),
+        ...     "Se": mass2.Channel.from_ljh(pathSe),
+        ...     "Xe": mass2.Channel.from_ljh(pathXe),
+        ... }
+        >>> composite = mass2.Channel.combine_channels(sourcename="element", constituents=constituents)
+
+        This will create 5 mass2.Channel objects from 5 separate LJH files, perhaps corresponding to measurements of
+        x rays from distinct elemental samples. The `combine_channels` call will generate a new `mass2.Channel`
+        holding the data from all 5 objects, plus a new column named "element", which will be one of
+        {"Be", "Fe", "Ge", "Se", "Xe"}, according to which LJH file it came from.
+
+        Parameters
+        ----------
+        sourcename : str
+            The name of the new dataframe column that will indicate the separate source of the original data.
+        constituents : dict[str, mass2.Channel]
+            A dictionary of named `mass2.Channel` objects. Their keys in this dictionary will be the string value
+            of the new `sourcename` column in the dataframe of the resulting `Channel`.
+
+        Returns
+        -------
+        Channel
+            A channel formed by combining the dataframes of the values of `constituents`, and assuming the header
+            info of the first entry in that dictionary applies to all other entries.
+        """
+        # We'll copy the header and other non-dataframe stuff from the first constituent.
+        combined_chan = next(iter(constituents.values()))
+        df = pl.DataFrame()
+        for k, ch in constituents.items():
+            assert ch.frametime_s == combined_chan.frametime_s
+            assert ch.n_presamples == combined_chan.n_presamples
+            assert ch.n_samples == combined_chan.n_samples
+            df = df.vstack(ch.df.with_columns(pl.lit(k).alias(sourcename)))
+        return replace(combined_chan, df=df, npulses=len(df))
 
     def with_experiment_state_df(self, df_es: pl.DataFrame, force_timestamp_monotonic: bool = False) -> "Channel":
         """Add experiment states from an existing dataframe"""

--- a/mass2/core/channels.py
+++ b/mass2/core/channels.py
@@ -561,10 +561,10 @@ class Channels:
         return self.with_experiment_state_df(df_es)
 
     def with_external_trigger_by_path(
-            self,
-            path: str | None,
-            output_control: ExtTriggerControl = ExtTriggerControl(),
-            ) -> "Channels":
+        self,
+        path: str | None,
+        output_control: ExtTriggerControl = ExtTriggerControl(),
+    ) -> "Channels":
         """Return a copy of this Channels object with external trigger information added, loaded
         from the given path or EVENTUALLY (if None) inferring it from an LJH file (not yet implemented).
 
@@ -688,6 +688,34 @@ class Channels:
     def from_oneChannel(cls, ch: Channel) -> "Channels":
         "Create a Channels object from a single Channel object"
         return Channels({ch.ch_num: ch}, ch.header.description)
+
+    @classmethod
+    def combine_channels(cls, sourcename: str, constituents: dict[str, "Channels"]) -> "Channels":
+        """Combine 2 or more compatible `mass2.Channels` objects into one. See `mass2.Channel.combine_channels()`
+        for more info about what "compatible" might mean. Certainly all `Channel` objects should have equal
+        `n_samples`, `n_presamples`, and `frametime_s`.
+
+        BEWARE: this will entail a copy of all raw data in all input LJH files, as far as we know.
+        That's a memory-intensive request. Use for small files only!
+
+        Parameters
+        ----------
+        sourcename : str
+            Each `Channel` object will get a new column in its dataframe with this name.
+        constituents : dict[str, mass2.Channels]
+            The keys in this dictionary will become values in the `sourcename` data frame.
+
+        Returns
+        -------
+        Channels
+            An object combining the named values in the `constitutents` input.
+        """
+        base = next(iter(constituents.values()))
+        chdict: dict[int, mass2.Channel] = {}
+        for chnum in base.channels.keys():
+            d = {k: v.channels[chnum] for (k, v) in constituents.items()}
+            chdict[chnum] = mass2.Channel.combine_channels(sourcename=sourcename, constituents=d)
+        return Channels(chdict, base.description)
 
     @classmethod
     def from_df(

--- a/tests/core/test_channels.py
+++ b/tests/core/test_channels.py
@@ -43,6 +43,25 @@ def dummy_channel(npulses=100, seed=4, signal=np.zeros(50, dtype=np.int16), ch_n
     return ch
 
 
+def test_with_columns():
+    """Verify 3 different syntax choices for adding columns in `mass2.Channel.with_columns()`.
+    See issue #139 for more context. Use
+    1. Named arguments, either pl.Expr or numpy array-like
+    2. Arguments as a sequence of pl.Series
+    3. A full pl.DataFrame
+    """
+    ch = dummy_channel().summarize_pulses()
+    rt = ch.df["pulse_rms"].to_numpy() ** 0.5
+    df = pl.DataFrame({"F": pl.Series(rt), "G": pl.Series(rt)})
+    ch = (
+        ch.with_columns(A=pl.col("pulse_rms").sqrt(), B=pl.col("pulse_rms") ** 0.5, C=rt)
+        .with_columns(pl.col("pulse_rms").sqrt().alias("D"), pl.col("pulse_rms").sqrt().alias("E"))
+        .with_columns(df)
+    )
+    for columnname in "ABCDEFG":
+        assert np.allclose(ch.df[columnname].to_numpy(), rt)
+
+
 def test_ljh_fractional_record(tmp_path):
     "Verify that it's allowed to open an LJH file with an non-integer # of binary records"
     # It should not be an error to open an LJH file with a non-integer number of records.
@@ -308,7 +327,7 @@ def test_col_map_step():
 def test_pretrig_mean_jump_fix_step():
     ch = dummy_channel()
     pretrig_mean = np.arange(len(ch.df)) % 50 + 725
-    ch = ch.with_columns(pl.DataFrame({"pretrig_mean": pretrig_mean}))
+    ch = ch.with_columns(pretrig_mean=pretrig_mean)
     ch2 = ch.correct_pretrig_mean_jumps(period=50)
     assert "pulse" in ch2.df.columns
     assert all(np.diff(ch2.df["ptm_jf"].to_numpy()) == 1)
@@ -332,7 +351,8 @@ def test_extract_column_names_from_polars_expr():
 
 def test_select_step():
     ch = dummy_channel()
-    ch = ch.with_columns(pl.DataFrame({"a": np.arange(len(ch.df)), "b": np.arange(len(ch.df)) * 2}))
+    n = len(ch.df)
+    ch = ch.with_columns(a=np.arange(n), b=(2 * np.arange(n)))
     ch2 = ch.with_select_step({"a*5": pl.col("a") * 5, "a+b": pl.col("a") + pl.col("b")})
     assert "pulse" in ch2.df.columns
     assert all(ch2.df["a*5"].to_numpy() == ch.df["a"].to_numpy() * 5)
@@ -365,7 +385,8 @@ def test_filtering_steps():
 
 def test_categorize_step():
     ch = dummy_channel(npulses=10)
-    ch = ch.with_columns(pl.DataFrame({"a": np.arange(len(ch.df)), "b": np.arange(len(ch.df)) * 2}))
+    n = len(ch.df)
+    ch = ch.with_columns(a=np.arange(n), b=(2 * np.arange(n)))
     category_condition_dict = {
         "alessthan5": pl.col("a") < 5,
         "b10": pl.col("b") == 10,

--- a/tests/core/test_channels.py
+++ b/tests/core/test_channels.py
@@ -62,6 +62,41 @@ def test_with_columns():
         assert np.allclose(ch.df[columnname].to_numpy(), rt)
 
 
+def test_combine_channels():
+    # Check Channel.combine_channels()
+    N1, N2 = 70, 30
+    ch1 = dummy_channel(npulses=N1)
+    ch2 = dummy_channel(npulses=N2)
+    d1 = {
+        "set1": ch1,
+        "set2": ch2,
+    }
+    ch = mass2.Channel.combine_channels("sourcenumber", d1)
+    assert len(ch1.df) == N1
+    assert len(ch2.df) == N2
+    assert len(ch.df) == N1 + N2
+    assert "sourcenumber" not in ch2.df.columns
+    assert "sourcenumber" in ch.df.columns
+    assert len(ch.df.filter(pl.col("sourcenumber") == "set1")) == N1
+    assert len(ch.df.filter(pl.col("sourcenumber") == "set2")) == N2
+
+    # Check Channels.combine_channels()
+    data1 = mass2.Channels.from_oneChannel(ch1)
+    data2 = mass2.Channels.from_oneChannel(ch2)
+    d2 = {
+        "sampleA": data1,
+        "sampleB": data2,
+    }
+    data = mass2.Channels.combine_channels("samplecode", d2)
+    assert data1.ch0.npulses == N1
+    assert data2.ch0.npulses == N2
+    assert data.ch0.npulses == N1 + N2
+    assert "samplecode" not in data1.ch0.df.columns
+    assert "samplecode" in data.ch0.df.columns
+    assert len(data.ch0.df.filter(pl.col("samplecode") == "sampleA")) == N1
+    assert len(data.ch0.df.filter(pl.col("samplecode") == "sampleB")) == N2
+
+
 def test_ljh_fractional_record(tmp_path):
     "Verify that it's allowed to open an LJH file with an non-integer # of binary records"
     # It should not be an error to open an LJH file with a non-integer number of records.


### PR DESCRIPTION
Improves some UX problems I found when trying to work with our TKID data. Specifically, Ian took 4 LJH files for a single TKID, one for each of several x-ray emitting samples. It was convenient to join them into one "`Channel`" object for combined analysis.

Changes include:
1. Generalizes the `Channel.with_columns(...)` method to behave more like the `pl.DataFrame` method of the same name. Constructing a `DataFrame` from one or a few expressions is no longer needed to use the `with_columns(...)` method. It can now accept:
   * a list of `Series` or other expressions,
   *  a named list of them, 
   * OR an existing `DataFrame`.
2. Adds a `Channel.combine_channels()` class method to easily join N runs into one analysis unit, where the data frame gains a column to indicate which of the N source runs it came from.
3. Adds analogous class method to `Channels` object, too.
4. Tests all of the above.

Example:
```python
constituents = {
    "Be": mass2.Channel.from_ljh(pathBe),
    "Fe": mass2.Channel.from_ljh(pathFe),
    "Ge": mass2.Channel.from_ljh(pathGe),
    "Se": mass2.Channel.from_ljh(pathSe),
    "Xe": mass2.Channel.from_ljh(pathXe),
}
composite = mass2.Channel.combine_channels(sourcename="element", constituents=constituents)
```

Fixes #139.

