### PR TITLE
Use ruff-action v4 to avoid Node.js version 20

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -56,7 +56,7 @@ jobs:
 
     - name: Run ruff formatter (only on most recent Python version)
       if: ${{ matrix.python-version == '3.14' }}
-      uses: astral-sh/ruff-action@v3
+      uses: astral-sh/ruff-action@v4.0.0
       with:
         version: "latest"
         args: "format"


### PR DESCRIPTION
Node.js version 20 is deprecated, apparently. Or so GH Actions keeps warning me. This change in `ruff-action` to use version 4 of that Action avoids Node.js 20, solving the problem.