### PR TITLE
Feature: Lazy loading, batching, IPC caching, and multi-run concatenation fixes

### DIFF
--- a/mass2/calibration/hci_lines.py
+++ b/mass2/calibration/hci_lines.py
@@ -11,6 +11,7 @@ Paul Szypryt
 """
 
 import importlib.resources as pkg_resources
+from typing import Any
 import numpy as np
 from numpy.typing import ArrayLike
 import pickle
@@ -70,6 +71,31 @@ class NIST_ASD:
 
         return list(self.NIST_ASD_Dict[element].keys())
 
+    def _get_level_entry(
+        self,
+        iLevel: str,
+        element: str,
+        spectralCharge: int,
+        units: str,
+        getUncertainty: bool,
+        requiredConf: str | None,
+        requiredTerm: str | None,
+        requiredJVal: str | None,
+    ) -> Any | None:
+        """Parse iLevel string and return its value if it matches all filters, else None. Raises ValueError if unparseable."""
+        conf, term, j_str = iLevel.split()
+        JVal = j_str.split("=")[1]
+        if not (
+            (requiredConf is None or conf == requiredConf)
+            and (requiredTerm is None or term == requiredTerm)
+            and (requiredJVal is None or JVal == requiredJVal)
+        ):
+            return None
+        data = self.NIST_ASD_Dict[element][spectralCharge][iLevel]
+        if units == "cm-1":
+            return data if getUncertainty else data[0]
+        return [v * INVCM_TO_EV for v in data] if getUncertainty else INVCM_TO_EV * data[0]
+
     def getAvailableLevels(
         self,
         element: str,
@@ -114,37 +140,18 @@ class NIST_ASD:
         levelsDict: dict = {}
         numLevels = 0
         for iLevel in list(self.NIST_ASD_Dict[element][spectralCharge].keys()):
+            if maxLevels is not None and numLevels == maxLevels:
+                return levelsDict
             try:
-                # Check to see if we reached maximum number of levels to return
-                if maxLevels is not None:
-                    if numLevels == maxLevels:
-                        return levelsDict
-                # If required, check to see if level matches search conf, term, JVal
-                includeTerm = False
-                includeJVal = False
-                conf, term, j_str = iLevel.split()
-                JVal = j_str.split("=")[1]
-                includeConf = (requiredConf is None) or conf == requiredConf
-                includeTerm = (requiredTerm is None) or term == requiredTerm
-                includeJVal = (requiredJVal is None) or JVal == requiredJVal
-
-                # Include levels that match, in either cm-1 or eV
-                if includeConf and includeTerm and includeJVal:
-                    numLevels += 1
-                    if units == "cm-1":
-                        if getUncertainty:
-                            levelsDict[iLevel] = self.NIST_ASD_Dict[element][spectralCharge][iLevel]
-                        else:
-                            levelsDict[iLevel] = self.NIST_ASD_Dict[element][spectralCharge][iLevel][0]
-                    elif units == "eV":
-                        if getUncertainty:
-                            levelsDict[iLevel] = [
-                                iValue * INVCM_TO_EV for iValue in self.NIST_ASD_Dict[element][spectralCharge][iLevel]
-                            ]
-                        else:
-                            levelsDict[iLevel] = INVCM_TO_EV * self.NIST_ASD_Dict[element][spectralCharge][iLevel][0]
+                value = self._get_level_entry(
+                    iLevel, element, spectralCharge, units, getUncertainty, requiredConf, requiredTerm, requiredJVal
+                )
             except ValueError:
                 f"Warning: cannot parse level: {iLevel}"
+                continue
+            if value is not None:
+                levelsDict[iLevel] = value
+                numLevels += 1
         return levelsDict
 
     def getSingleLevel(

--- a/mass2/core/analysis_algorithms.py
+++ b/mass2/core/analysis_algorithms.py
@@ -28,6 +28,31 @@ LOG = logging.getLogger("mass")
 
 
 @njit
+def _estimate_rise_time_inner(
+    pulse_data: NDArray,
+    nPretrig: int,
+    idx_last_pk: int,
+    baseline_value: NDArray,
+    value_at_peak: NDArray,
+    timebase: float,
+    npulses: int,
+) -> NDArray:
+    MINTHRESH, MAXTHRESH = 0.1, 0.9
+    rising_data = (pulse_data[:, nPretrig : idx_last_pk + 1] - baseline_value[:, np.newaxis]) / value_at_peak[:, np.newaxis]
+    last_idx = (rising_data > MAXTHRESH).argmax(axis=1) - 1
+    first_idx = (rising_data > MINTHRESH).argmax(axis=1)
+    last_idx[last_idx < first_idx] = first_idx[last_idx < first_idx] + 1
+    last_idx[last_idx == rising_data.shape[1]] = rising_data.shape[1] - 1
+    pulsenum = np.arange(npulses)
+    y_diff = np.asarray(rising_data[pulsenum, last_idx] - rising_data[pulsenum, first_idx], dtype=float)
+    y_diff[y_diff < timebase] = timebase
+    time_diff = timebase * (last_idx - first_idx)
+    rise_time = time_diff / y_diff
+    rise_time[y_diff <= 0] = -9.9e-6
+    return rise_time
+
+
+@njit
 def estimateRiseTime(pulse_data: ArrayLike, timebase: float, nPretrig: int) -> NDArray:
     """Computes the rise time of timeseries <pulse_data>, where the time steps are <timebase>.
     <pulse_data> can be a 2D array where each row is a different pulse record, in which case
@@ -49,8 +74,6 @@ def estimateRiseTime(pulse_data: ArrayLike, timebase: float, nPretrig: int) -> N
     Returns:
         An ndarray of dimension 1, giving the rise times.
     """
-    MINTHRESH, MAXTHRESH = 0.1, 0.9
-
     # If pulse_data is a 1D array, turn it into 2
     pulse_data = np.asarray(pulse_data)
     ndim = len(pulse_data.shape)
@@ -70,22 +93,7 @@ def estimateRiseTime(pulse_data: ArrayLike, timebase: float, nPretrig: int) -> N
 
     npulses = pulse_data.shape[0]
     try:
-        rising_data = (pulse_data[:, nPretrig : idx_last_pk + 1] - baseline_value[:, np.newaxis]) / value_at_peak[:, np.newaxis]
-        # Find the last and first indices at which the data are in (0.1, 0.9] times the
-        # peak value. Then make sure last is at least 1 past first.
-        last_idx = (rising_data > MAXTHRESH).argmax(axis=1) - 1
-        first_idx = (rising_data > MINTHRESH).argmax(axis=1)
-        last_idx[last_idx < first_idx] = first_idx[last_idx < first_idx] + 1
-        last_idx[last_idx == rising_data.shape[1]] = rising_data.shape[1] - 1
-
-        pulsenum = np.arange(npulses)
-        y_diff = np.asarray(rising_data[pulsenum, last_idx] - rising_data[pulsenum, first_idx], dtype=float)
-        y_diff[y_diff < timebase] = timebase
-        time_diff = timebase * (last_idx - first_idx)
-        rise_time = time_diff / y_diff
-        rise_time[y_diff <= 0] = -9.9e-6
-        return rise_time
-
+        return _estimate_rise_time_inner(pulse_data, nPretrig, idx_last_pk, baseline_value, value_at_peak, timebase, npulses)
     except ValueError:
         return -9.9e-6 + np.zeros(npulses, dtype=float)
 

--- a/mass2/core/channel.py
+++ b/mass2/core/channel.py
@@ -15,10 +15,12 @@ import pylab as plt
 from matplotlib.colors import Colormap
 from matplotlib.backend_bases import MouseEvent
 import marimo as mo
-import functools
 import numpy as np
 import time
 from pathlib import Path
+from functools import wraps
+import gc
+import warnings
 
 import tzlocal
 
@@ -99,6 +101,7 @@ class Channel:
     steps: Recipe = field(default_factory=Recipe.new_empty, repr=False)
     steps_elapsed_s: list[float] = field(default_factory=list)
     transform_raw: Callable | None = None
+    data_sources: list[str] = field(default_factory=list, repr=False)  # source file paths used to reconstruct pulse
 
     def __post_init__(self) -> None:
         # If column "pulse" exists and is an Array, make sure it has the same number of samples as the header
@@ -132,6 +135,28 @@ class Channel:
     def n_samples(self) -> int:
         "Samples per pulse, from the file header"
         return self.header.n_samples
+
+    def requires_pulse(func: Callable) -> Callable:  # type: ignore[misc]
+        """Decorator that transparently loads pulse before calling func and drops it afterward if it was absent.
+
+        If the channel already has the 'pulse' column, the decorated function is called unchanged.
+        If pulse is absent, a temporary copy with pulse loaded is used; the result then has pulse
+        dropped again (when the result is a Channel) so the caller's memory footprint is unchanged.
+        Non-Channel return values (ndarray, scalars, etc.) are returned as-is.
+        """
+
+        @wraps(func)
+        def wrapper(self: "Channel", *args: Any, **kwargs: Any) -> Any:
+            had_pulse = "pulse" in self.df.columns
+            if had_pulse:
+                return func(self, *args, **kwargs)
+            temp_chan = self.load_pulse()
+            result = func(temp_chan, *args, **kwargs)
+            if isinstance(result, Channel):
+                return result.drop_pulse()
+            return result
+
+        return wrapper
 
     def head(self, n: int) -> "Channel":
         "Return a new Channel, using only the first `n` pulse records (or if n<0, then all but the last abs(n))."
@@ -190,6 +215,7 @@ class Channel:
         step = self.steps[index]
         return step, index
 
+    @requires_pulse
     def step_plot(self, step_ind: int, **kwargs: Any) -> plt.Axes:
         """Make a debug plot for the given step index, supporting negative indices."""
         step, step_ind = self.get_step(step_ind)
@@ -197,6 +223,7 @@ class Channel:
             df_after = self.df
         else:
             df_after = self.df_history[step_ind + 1]
+            df_after = self._pulse_to_df(df_after)
         return step.dbg_plot(df_after, **kwargs)
 
     def hist(
@@ -395,7 +422,8 @@ class Channel:
         if cont_color_col is not None:
             columns_to_keep.append(cont_color_col)
         df_small = (
-            self.df.lazy()
+            self.df
+            .lazy()
             .with_row_index(name=index_name)
             .filter(filter_expr)
             .select(*columns_to_keep)
@@ -519,6 +547,7 @@ class Channel:
             plt.legend(title=color_col)
         plot_zoomable()
 
+    @requires_pulse
     def plot_pulses(  # noqa: PLR0917
         self,
         length: int = 30,
@@ -640,7 +669,7 @@ class Channel:
         pulses = df[pulse_field]
         ptmean = df["pretrig_mean"]
         for i in range(N):
-            pulse = pulses[i].to_numpy()
+            pulse = np.array(pulses[i])
             color = cmap(i / N)
             if subtract_baseline:
                 pulse = pulse - ptmean[i]  # noqa: PLR6104
@@ -806,7 +835,7 @@ class Channel:
             self,
             df=df2,
             good_expr=step.good_expr,
-            df_history=self.df_history + [self.df],
+            df_history=self.df_history + [self.df.drop("pulse", strict=False)],
             steps=self.steps.with_step(step),
             steps_elapsed_s=self.steps_elapsed_s + [elapsed_s],
         )
@@ -887,14 +916,19 @@ class Channel:
                 good_expr = good_expr.and_(this_iter_good_expr)
         return self.with_good_expr(good_expr, replace)
 
-    @functools.cache
+    @requires_pulse
     def typical_peak_ind(self, col: str = "pulse") -> int:
         """Return the typical peak index of the given column, using the median peak index for the first 100 pulses."""
-        raw = self.df.limit(100)[col].to_numpy()
+        pulse_series = self.df.limit(100)[col]
+        try:
+            raw = pulse_series.to_numpy()
+        except TypeError:
+            raw = np.vstack(pulse_series.to_list())
         if self.transform_raw is not None:
             raw = self.transform_raw(raw)
         return int(np.median(raw.argmax(axis=1)))
 
+    @requires_pulse
     def summarize_pulses(self, col: str = "pulse", pretrigger_ignore_samples: int = 0, peak_index: int | None = None) -> "Channel":
         """Summarize the pulses, adding columns for pulse height, pretrigger mean, etc."""
         if peak_index is None:
@@ -966,6 +1000,7 @@ class Channel:
         )
         return self.with_step(step)
 
+    @requires_pulse
     def compute_average_pulse(self, pulse_col: str = "pulse", use_expr: pl.Expr = pl.lit(True), limit: int = 2000) -> NDArray:
         """Compute an average pulse given a use expression.
 
@@ -983,20 +1018,16 @@ class Channel:
         NDArray
             _description_
         """
-        avg_pulse = (
-            self.df.lazy()
-            .filter(self.good_expr)
-            .filter(use_expr)
-            .select(pulse_col)
-            .limit(limit)
-            .collect()
-            .to_series()
-            .to_numpy()
-            .mean(axis=0)
-        )
+        pulse_series = self.df.lazy().filter(self.good_expr).filter(use_expr).select(pulse_col).limit(limit).collect().to_series()
+        try:
+            avg_pulse = pulse_series.to_numpy().mean(axis=0)
+        except TypeError:
+            avg_pulse = np.vstack(pulse_series.to_list()).mean(axis=0)
+
         avg_pulse -= avg_pulse[: self.n_presamples].mean()
         return avg_pulse
 
+    @requires_pulse
     def filter5lag(  # noqa: PLR0917
         self,
         pulse_col: str = "pulse",
@@ -1091,6 +1122,7 @@ class Channel:
         )
         return self.with_step(step)
 
+    @requires_pulse
     def filter1lag(  # noqa: PLR0917
         self,
         pulse_col: str = "pulse",
@@ -1174,6 +1206,7 @@ class Channel:
         )
         return self.with_step(step)
 
+    @requires_pulse
     def compute_ats_model(self, pulse_col: str, use_expr: pl.Expr = pl.lit(True), limit: int = 2000) -> tuple[NDArray, NDArray]:
         """Compute the average pulse and arrival-time model for an ATS filter.
         We use the first `limit` pulses that pass `good_expr` and `use_expr`.
@@ -1193,7 +1226,8 @@ class Channel:
             _description_
         """
         df = (
-            self.df.lazy()
+            self.df
+            .lazy()
             .filter(self.good_expr)
             .filter(use_expr)
             .limit(limit)
@@ -1215,7 +1249,12 @@ class Channel:
         df = df.with_columns(ATime=ATime).filter(np.abs(ATime) < 0.45).drop("promptshifted")
 
         # Compute mean pulse and dt model as the offset and slope of a linear fit to each pulse sample vs ATime
-        pulse = df["pulse"].to_numpy()
+        pulse_series = df["pulse"]
+        if isinstance(pulse_series.dtype, pl.List):
+            pulse = np.vstack(pulse_series.to_list())
+        else:
+            pulse = pulse_series.to_numpy()
+
         avg_pulse = np.zeros(self.n_samples, dtype=float)
         dt_model = np.zeros(self.n_samples, dtype=float)
         for i in range(self.n_presamples, self.n_samples):
@@ -1224,6 +1263,7 @@ class Channel:
             avg_pulse[i] = offset
         return avg_pulse, dt_model
 
+    @requires_pulse
     def filterATS(
         self,
         pulse_col: str = "pulse",
@@ -1386,34 +1426,120 @@ class Channel:
         return id(self) == id(other)
 
     @classmethod
+    def _load_from_ipc_cache(
+        cls,
+        data_ipc_path: Path,
+        header_ipc_path: Path,
+        path: "str | Path",
+        load_pulses: bool,
+        noise_channel: "NoiseChannel | None",
+        transform_raw: "Callable | None",
+    ) -> "Channel":
+        if load_pulses:
+            df = pl.read_ipc(data_ipc_path, memory_map=True)
+        else:
+            df = pl.scan_ipc(data_ipc_path).select(pl.exclude("pulse")).collect()
+        header_df = pl.read_ipc(header_ipc_path)
+        if "source_file" not in df.columns:
+            df = df.with_columns(
+                pl.lit(str(path)).alias("source_file").cast(pl.Categorical),
+                pl.int_range(0, len(df), dtype=pl.Int64).alias("source_id"),
+            )
+        subframediv = None
+        if "Subframe divisions" in header_df.columns:
+            subframediv = header_df["Subframe divisions"][0]
+        elif "Number of rows" in header_df.columns:
+            subframediv = header_df["Number of rows"][0]
+        return cls(
+            df,
+            header=ChannelHeader.from_ljh_header_df(header_df),
+            npulses=len(df),
+            subframediv=subframediv,
+            noise=noise_channel,
+            transform_raw=transform_raw,
+            data_sources=[str(path)],
+        )
+
+    @classmethod
     def from_ljh(
         cls,
         path: str | Path,
         noise_path: str | Path | None = None,
         keep_posix_usec: bool = False,
         transform_raw: Callable | None = None,
+        use_cache: bool = True,
+        generate_cache: bool = False,
+        load_pulses: bool = True,
     ) -> "Channel":
         """Load a Channel from an LJH file, optionally with a NoiseChannel from a corresponding noise LJH file."""
         if not noise_path:
             noise_channel = None
         else:
-            noise_channel = NoiseChannel.from_ljh(noise_path)
+            noise_channel = NoiseChannel.from_ljh(
+                noise_path, use_cache=use_cache, generate_cache=generate_cache, load_pulses=load_pulses
+            )
+        path_obj = Path(path)
+        data_ipc_path = path_obj.with_suffix(".ipc")
+        header_ipc_path = path_obj.with_suffix(".header.ipc")
+        cache_exists = data_ipc_path.exists() and header_ipc_path.exists()
+        cache_is_valid = False
+        if cache_exists:
+            if path_obj.stat().st_mtime < data_ipc_path.stat().st_mtime:
+                cache_is_valid = True
+            else:
+                print(f"Cache for {path_obj.name} is out of date. Regenerating...")
+        if use_cache and cache_is_valid:
+            try:
+                return cls._load_from_ipc_cache(data_ipc_path, header_ipc_path, path, load_pulses, noise_channel, transform_raw)
+            except Exception as e:
+                print(f"Warning: Corrupted cache detected for {path_obj.name} ({e}). Falling back to raw LJH.")
         ljh = mass2.LJHFile.open(path)
         df, header_df = ljh.to_polars(keep_posix_usec)
+        if "source_file" not in df.columns:
+            df = df.with_columns(
+                pl.lit(str(path)).alias("source_file").cast(pl.Categorical),
+                pl.int_range(0, len(df), dtype=pl.Int64).alias("source_id"),
+            )
+        if generate_cache:
+            print(f"Generating IPC cache for {path_obj.name}...")
+            tmp_data_path = Path(str(data_ipc_path) + ".tmp")
+            tmp_header_path = Path(str(header_ipc_path) + ".tmp")
+            df.write_ipc(tmp_data_path, compression="uncompressed")
+            header_df.write_ipc(tmp_header_path, compression="uncompressed")
+            tmp_data_path.replace(data_ipc_path)
+            tmp_header_path.replace(header_ipc_path)
+            if use_cache:
+                del df, header_df
+                if load_pulses:
+                    df = pl.read_ipc(data_ipc_path, memory_map=True)
+                else:
+                    df = pl.scan_ipc(data_ipc_path).select(pl.exclude("pulse")).collect()
+                header_df = pl.read_ipc(header_ipc_path)
+        if not load_pulses and "pulse" in df.columns:
+            df = df.drop("pulse", strict=False)
         header = ChannelHeader.from_ljh_header_df(header_df)
-        channel = cls(
-            df, header=header, npulses=ljh.npulses, subframediv=ljh.subframediv, noise=noise_channel, transform_raw=transform_raw
+        npulses = ljh.npulses
+        subframediv = ljh.subframediv
+        return cls(
+            df,
+            header=header,
+            npulses=npulses,
+            subframediv=subframediv,
+            noise=noise_channel,
+            transform_raw=transform_raw,
+            data_sources=[str(path)],
         )
-        return channel
 
     @classmethod
-    def from_off(cls, off: OffFile) -> "Channel":
+    def from_off(cls, off: OffFile, load_pulses: bool = True) -> "Channel":
         """Load a Channel from an OFF file."""
         assert off._mmap is not None
         df = pl.from_numpy(np.asarray(off._mmap))
         df = (
-            df.select(
-                pl.from_epoch("unixnano", time_unit="ns")
+            df
+            .select(
+                pl
+                .from_epoch("unixnano", time_unit="ns")
                 .dt.cast_time_unit("us")
                 .dt.convert_time_zone(_local_timezone_name)
                 .alias("timestamp")
@@ -1423,6 +1549,11 @@ class Channel:
         )
         df_header = pl.DataFrame(off.header)
         df_header = df_header.with_columns(pl.Series("Filename", [off.filename]))
+        if "source_file" not in df.columns:
+            df = df.with_columns(
+                pl.lit(str(off.filename)).alias("source_file").cast(pl.Categorical),
+                pl.int_range(0, len(df), dtype=pl.Int64).alias("source_id"),
+            )
         header = ChannelHeader(
             f"{os.path.split(off.filename)[1]}",
             off.filename,
@@ -1432,7 +1563,9 @@ class Channel:
             off._mmap["recordSamples"][0],
             df_header,
         )
-        channel = cls(df, header, off.nRecords, subframediv=off.subframediv)
+        channel = cls(df, header, off.nRecords, subframediv=off.subframediv, data_sources=[str(off.filename)])
+        if not load_pulses and "pulse" in channel.df.columns:
+            channel = channel.drop_pulse()
         return channel
 
     @classmethod
@@ -1529,6 +1662,158 @@ class Channel:
         header = ChannelHeader(description, source, ch_num, frametime_s, n_presamples=npresamples, n_samples=nsamples, df=pulse_df)
         return cls(pulse_df, header, npulses, noise=nch)
 
+    def _pulse_to_df(self, target_df: pl.DataFrame, use_cache: bool = True, generate_cache: bool = False) -> pl.DataFrame:
+        """Reconstruct the 'pulse' column for target_df by reading from the original source files.
+
+        Uses the 'source_file' and 'source_id' columns in target_df to look up the correct rows
+        from each source LJH or IPC file. Falls back to a sequential-index assumption when those
+        columns are absent and data_sources has exactly one entry (unreliable for filtered channels).
+        """
+        if "pulse" in target_df.columns:
+            return target_df
+        if "source_file" not in target_df.columns:
+            if self.data_sources and len(self.data_sources) == 1:
+                warnings.warn(
+                    "load_pulse: source_file/source_id columns absent; assuming sequential row order matches "
+                    "the source file. This is INCORRECT if the channel has been filtered.",
+                    RuntimeWarning,
+                    stacklevel=3,
+                )
+                target_df = target_df.with_columns(
+                    pl.lit(self.data_sources[0]).alias("source_file").cast(pl.Categorical),
+                    pl.int_range(0, len(target_df), dtype=pl.Int64).alias("source_id"),
+                )
+            elif self.data_sources:
+                # Multiple sources but no per-row provenance: ambiguous, can't load.
+                warnings.warn(
+                    "Can't load pulse column without source_file and source_id columns.",
+                    RuntimeWarning,
+                    stacklevel=3,
+                )
+                return target_df
+            else:
+                # No provenance at all — this is a genuinely pulse-free channel (e.g. calibration-only).
+                return target_df
+        target_df = target_df.with_row_index("__orig_idx")
+        required_sources = target_df["source_file"].unique().to_list()
+        result_dfs = []
+        for src in required_sources:
+            src_df = target_df.filter(pl.col("source_file") == src)
+            if len(src_df) == 0:
+                continue
+            src_path = Path(src)
+            ipc_path = src_path.with_suffix(".ipc")
+            if use_cache and ipc_path.exists():
+                raw_source_df = pl.read_ipc(ipc_path, memory_map=True)
+                source_ids = src_df["source_id"].to_numpy()
+                pulse_series = raw_source_df["pulse"].gather(source_ids)
+                src_df = src_df.with_columns(pulse_series)
+                del raw_source_df
+                gc.collect()
+                result_dfs.append(src_df)
+                continue
+            if src.endswith(".ljh") or src.endswith(".noi"):
+                temp_chan = self.__class__.from_ljh(src, use_cache=use_cache, generate_cache=generate_cache, load_pulses=True)
+            elif src.endswith(".off"):
+                temp_chan = self.__class__.from_off(mass2.core.OffFile(src), load_pulses=True)
+            else:
+                result_dfs.append(src_df)
+                continue
+            source_ids = src_df["source_id"].to_numpy()
+            pulse_series = temp_chan.df["pulse"].gather(source_ids)
+            src_df = src_df.with_columns(pulse_series)
+            del temp_chan
+            gc.collect()
+            result_dfs.append(src_df)
+        if result_dfs:
+            return pl.concat(result_dfs).sort("__orig_idx").drop("__orig_idx")
+        return target_df.drop("__orig_idx", strict=False)
+
+    def load_pulse(self, use_cache: bool = True, generate_cache: bool = False) -> "Channel":
+        """Return a copy of this channel with the 'pulse' column restored from its source file(s).
+
+        Requires 'source_file' and 'source_id' columns (added automatically by from_ljh).
+        Is a no-op if pulse is already present.
+
+        Parameters
+        ----------
+        use_cache : bool, optional
+            Read from the .ipc cache next to the LJH if it exists and is up to date, by default True.
+        generate_cache : bool, optional
+            Write a .ipc cache after reading the LJH, by default False.
+        """
+        rehydrated_df = self._pulse_to_df(self.df, use_cache=use_cache, generate_cache=generate_cache)
+        noise2 = self.noise.load_pulse(use_cache, generate_cache) if self.noise else None
+        return dataclasses.replace(self.with_replacement_df(rehydrated_df), noise=noise2)
+
+    def drop_pulse(self) -> "Channel":
+        """Return a copy of this channel with the 'pulse' column removed to free RAM.
+
+        Is a no-op (except for noise) if pulse is already absent. The source provenance columns
+        (source_file, source_id) are kept so pulse can be reloaded later via load_pulse().
+        """
+        noise2 = self.noise.drop_pulse() if self.noise else None
+        if "pulse" in self.df.columns:
+            return dataclasses.replace(self.with_replacement_df(self.df.drop("pulse", strict=False)), noise=noise2)
+        return dataclasses.replace(self, noise=noise2)
+
+    def iter_pulse_batches(self, use_cache: bool = True, generate_cache: bool = False, chunk_size: int = 65536) -> Iterable["Channel"]:
+        """Yield chunked copies of this channel, each with pulse loaded, for low-memory batch processing.
+
+        Reads one source file at a time and serves it in slices of chunk_size rows.
+        The channel must have a 'source_file' column (present after from_ljh with load_pulses=False).
+
+        Parameters
+        ----------
+        use_cache : bool, optional
+            Read from the .ipc cache next to the LJH if available and up to date, by default True.
+        generate_cache : bool, optional
+            Write a .ipc cache after reading each source LJH, by default False.
+        chunk_size : int, optional
+            Maximum number of pulse records per yielded batch, by default 65536.
+        """
+        if "source_file" not in self.df.columns:
+            raise pl.exceptions.ColumnNotFoundError(
+                "iter_pulse_batches requires a 'source_file' column. "
+                "Load the channel from LJH with load_pulses=False to enable batch processing."
+            )
+        noise_loaded = self.noise.load_pulse(use_cache, generate_cache) if self.noise else None
+        sources = self.df["source_file"].unique().to_list()
+        for src in sources:
+            src_df = self.df.filter(pl.col("source_file") == src)
+            if len(src_df) == 0:
+                continue
+            src_path = Path(src)
+            ipc_path = src_path.with_suffix(".ipc")
+            raw_source_df = None
+            temp_chan = None
+            if use_cache and ipc_path.exists():
+                candidate = pl.read_ipc(ipc_path, memory_map=True)
+                raw_source_df = candidate if "pulse" in candidate.columns else None
+            if raw_source_df is None:
+                if src.endswith(".ljh") or src.endswith(".noi"):
+                    temp_chan = self.__class__.from_ljh(src, use_cache=use_cache, generate_cache=generate_cache, load_pulses=True)
+                    raw_source_df = temp_chan.df
+                elif src.endswith(".off"):
+                    temp_chan = self.__class__.from_off(mass2.core.OffFile(src), load_pulses=True)
+                    raw_source_df = temp_chan.df
+            for i in range(0, len(src_df), chunk_size):
+                batch_df = src_df.slice(i, chunk_size)
+                if raw_source_df is not None and "pulse" not in batch_df.columns:
+                    source_ids = batch_df["source_id"].to_numpy()
+                    pulse_series = raw_source_df["pulse"].gather(source_ids)
+                    batch_df = batch_df.with_columns(pulse_series)
+                batch_chan = dataclasses.replace(self.with_replacement_df(batch_df), noise=noise_loaded)
+                yield batch_chan
+                del batch_df
+                del batch_chan
+                gc.collect()
+            if raw_source_df is not None:
+                del raw_source_df
+            if temp_chan is not None:
+                del temp_chan
+            gc.collect()
+
     @classmethod
     def combine_channels(cls, sourcename: str, constituents: dict[str, "Channel"]) -> "Channel":
         """Combine 2 or more channels into 1 (they presumably correspond to one microcalorimeter used
@@ -1576,13 +1861,17 @@ class Channel:
         """
         # We'll copy the header and other non-dataframe stuff from the first constituent.
         combined_chan = next(iter(constituents.values()))
-        df = pl.DataFrame()
+        dfs = []
         for k, ch in constituents.items():
             assert ch.frametime_s == combined_chan.frametime_s
             assert ch.n_presamples == combined_chan.n_presamples
             assert ch.n_samples == combined_chan.n_samples
-            df = df.vstack(ch.df.with_columns(pl.lit(k).alias(sourcename)))
-        return replace(combined_chan, df=df, npulses=len(df))
+            dfs.append(ch.df.with_columns(pl.lit(k).alias(sourcename)))
+        df = pl.concat(dfs)
+        all_sources = []
+        for ch in constituents.values():
+            all_sources.extend(ch.data_sources)
+        return replace(combined_chan, df=df, npulses=len(df), data_sources=all_sources)
 
     def with_experiment_state_df(self, df_es: pl.DataFrame, force_timestamp_monotonic: bool = False) -> "Channel":
         """Add experiment states from an existing dataframe"""
@@ -1643,7 +1932,8 @@ class Channel:
             df_subframe = df_subframe.with_columns(ms_next_ext_trig=(pl.col("dsf_next_ext_trig") * subframe_time_ms))
         if output_control.ms_nearest_trig:
             df_subframe = df_subframe.with_columns(
-                pl.when(pl.col("dsf_last_ext_trig") < pl.col("dsf_next_ext_trig"))
+                pl
+                .when(pl.col("dsf_last_ext_trig") < pl.col("dsf_next_ext_trig"))
                 .then(pl.col("dsf_last_ext_trig") * subframe_time_ms)
                 .otherwise(-pl.col("dsf_next_ext_trig") * subframe_time_ms)
                 .alias("ms_nearest_ext_trig")
@@ -1662,10 +1952,7 @@ class Channel:
 
     def with_replacement_df(self, df2: pl.DataFrame) -> "Channel":
         """Replace the dataframe with a new one, keeping all other attributes the same."""
-        return dataclasses.replace(
-            self,
-            df=df2,
-        )
+        return dataclasses.replace(self, df=df2, npulses=len(df2))
 
     def drop(self, *args: str) -> "Channel":
         "Return a Channel, after dropping one or more columns from the dataframe, by name"
@@ -1721,23 +2008,28 @@ class Channel:
 
     def concat_df(self, df: pl.DataFrame) -> "Channel":
         """Concat the given dataframe to the existing dataframe, keeping all other attributes the same.
-        If the new frame `df` has a history and/or steps, those will be lost"""
-        ch2 = Channel(
-            mass2.core.misc.concat_dfs_with_concat_state(self.df, df),
-            self.header,
-            self.npulses,
-            subframediv=self.subframediv,
-            noise=self.noise,
-            good_expr=self.good_expr,
+        df_history and steps are reset — do not use this on a channel with a filled recipe."""
+        combined_df = mass2.core.misc.concat_dfs_with_concat_state(self.df, df)
+        return dataclasses.replace(
+            self,
+            df=combined_df,
+            npulses=len(combined_df),
+            df_history=[],
+            steps=Recipe.new_empty(),
         )
-        # we won't copy over df_history and steps. I don't think you should use this when those are filled in?
-        return ch2
 
     def concat_ch(self, ch: "Channel") -> "Channel":
         """Concat the given channel's dataframe to the existing dataframe, keeping all other attributes the same.
-        If the new channel `ch` has a history and/or steps, those will be lost"""
-        ch2 = self.concat_df(ch.df)
-        return ch2
+        df_history and steps are reset — do not use this on a channel with a filled recipe."""
+        combined_df = mass2.core.misc.concat_dfs_with_concat_state(self.df, ch.df)
+        return dataclasses.replace(
+            self,
+            df=combined_df,
+            npulses=len(combined_df),
+            df_history=[],
+            steps=Recipe.new_empty(),
+            data_sources=list(dict.fromkeys(self.data_sources + ch.data_sources)),
+        )
 
     def phase_correct_mass_specific_lines(
         self,
@@ -1838,9 +2130,11 @@ class Channel:
                 plt.ylim(ymin=contents.min())
         print(f"Plotting {len(y)} out of {self.npulses} data points")
 
+    @requires_pulse
     def fit_pulse(self, index: int = 0, col: str = "pulse", verbose: bool = True) -> LineModelResult:
         """Fit a single pulse to a 2-exponential-with-tail model, returning the fit result."""
-        pulse = self.df[col][index].to_numpy()
+        raw = self.df[col][index]
+        pulse = raw if isinstance(raw, np.ndarray) else np.array(raw, dtype=np.int16)
         result = mass2.core.pulse_algorithms.fit_pulse_2exp_with_tail(pulse, npre=self.n_presamples, dt=self.frametime_s)
         if verbose:
             print(f"ch={self}")

--- a/mass2/core/channels.py
+++ b/mass2/core/channels.py
@@ -4,6 +4,7 @@ Data structures and methods for handling a group of microcalorimeter channels.
 
 from dataclasses import dataclass, field
 import dataclasses
+from functools import cache
 from collections.abc import Callable, Iterable
 from numpy.typing import ArrayLike
 from typing import Any
@@ -11,7 +12,6 @@ import polars as pl
 import pylab as plt
 import matplotlib
 import numpy as np
-import functools
 import joblib
 import traceback
 import lmfit
@@ -66,7 +66,7 @@ class Channels:
         descr = self.description + more.description + "\nWarning! created by with_more_channels()"
         return dataclasses.replace(self, channels=channels, bad_channels=bad, description=descr)
 
-    @functools.cache
+    @cache
     def dfg(self, exclude: str = "pulse") -> pl.DataFrame:
         """Return a DataFrame containing good pulses from each channel. Excludes the given columns (default "pulse")."""
         # return a dataframe containing good pulses from each channel,
@@ -346,19 +346,70 @@ class Channels:
         plt.title("Noise autocorrelation")
         plot_zoomable()
 
-    def map(self, f: Callable, allow_throw: bool = False) -> "Channels":
-        """Map function `f` over all channels, returning a new Channels object containing the new Channel objects."""
+    @staticmethod
+    def _apply_batched(f: Callable, channel: "Channel") -> "Channel":
+        processed_batches = []
+        for batch_chan in channel.iter_pulse_batches():
+            res_batch = f(batch_chan)
+            if not isinstance(res_batch, Channel):
+                raise TypeError(f"map(batched=True) requires f() to return a Channel, got {type(res_batch).__name__}")
+            processed_batches.append(res_batch.drop_pulse())
+        if not processed_batches:
+            return f(channel)
+        combined_df = pl.concat([batch.df for batch in processed_batches])
+        template = processed_batches[0]
+        n_history = len(template.df_history)
+        if n_history > 0 and all(len(b.df_history) == n_history for b in processed_batches):
+            combined_history = [pl.concat([b.df_history[i] for b in processed_batches]) for i in range(n_history)]
+        else:
+            combined_history = []
+        return dataclasses.replace(template, df=combined_df, df_history=combined_history, npulses=len(combined_df))
+
+    def map(self, f: Callable, allow_throw: bool = False, auto_load_pulse: bool = True, batched: bool = False) -> "Channels":
+        """Map function `f` over all channels, returning a new Channels object containing the results.
+
+        Parameters
+        ----------
+        f : Callable
+            A function that takes a Channel and returns a Channel.
+        allow_throw : bool, optional
+            If True, re-raise the first exception rather than collecting failures in bad_channels, by default False.
+        auto_load_pulse : bool, optional
+            If True and a channel lacks the 'pulse' column, automatically load pulse and retry on
+            ColumnNotFoundError / KeyError before marking the channel bad, by default True.
+        batched : bool, optional
+            If True and a channel lacks the 'pulse' column, iterate over the channel in
+            memory-efficient batches via iter_pulse_batches() rather than calling f(channel) once.
+            f() must return a Channel. Ignored when the channel already has pulse loaded, by default False.
+        """
         new_channels = {}
         new_bad_channels = {}
         for key, channel in self.channels.items():
             try:
+                if batched and "pulse" not in channel.df.columns:
+                    new_channels[key] = Channels._apply_batched(f, channel)
+                    continue
                 new_channels[key] = f(channel)
             except KeyboardInterrupt as kint:
                 raise kint
             except Exception as ex:
+                backtrace: str = traceback.format_exc()
+                if (
+                    auto_load_pulse
+                    and not batched
+                    and "pulse" not in channel.df.columns
+                    and isinstance(ex, (pl.exceptions.ColumnNotFoundError, KeyError))
+                ):
+                    try:
+                        temp_chan = channel.load_pulse()
+                        res_chan = f(temp_chan)
+                        new_channels[key] = res_chan.drop_pulse()
+                        continue
+                    except Exception as fallback_ex:
+                        ex = fallback_ex
+                        backtrace = traceback.format_exc()
                 error_type: type = type(ex)
                 error_message: str = str(ex)
-                backtrace: str = traceback.format_exc()
                 if allow_throw:
                     raise
                 print(f"{key=} {channel=} failed the step {f}")
@@ -368,6 +419,20 @@ class Channels:
         new_bad_channels = mass2.misc.merge_dicts_ordered_by_keys(self.bad_channels, new_bad_channels)
 
         return Channels(new_channels, self.description, bad_channels=new_bad_channels)
+
+    def drop_pulse(self) -> "Channels":
+        """Return a new Channels with the heavy 'pulse' column dropped from every channel and its noise."""
+        return dataclasses.replace(
+            self,
+            channels={k: ch.drop_pulse() for k, ch in self.channels.items()},
+        )
+
+    def load_pulse(self, use_cache: bool = True, generate_cache: bool = False) -> "Channels":
+        """Return a new Channels with the 'pulse' column rehydrated in every channel from its source LJH/IPC files."""
+        return dataclasses.replace(
+            self,
+            channels={k: ch.load_pulse(use_cache, generate_cache) for k, ch in self.channels.items()},
+        )
 
     def set_bad(self, ch_num: int, msg: str, require_ch_num_exists: bool = True) -> "Channels":
         """Return a copy of this Channels object with the given channel number marked as bad."""
@@ -406,7 +471,14 @@ class Channels:
         return id(self) == id(other)
 
     @classmethod
-    def from_ljh_path_pairs(cls, pulse_noise_pairs: Iterable[tuple[str, str]], description: str) -> "Channels":
+    def from_ljh_path_pairs(
+        cls,
+        pulse_noise_pairs: Iterable[tuple[str, str]],
+        description: str,
+        use_cache: bool = True,
+        generate_cache: bool = False,
+        load_pulses: bool = True,
+    ) -> "Channels":
         """
         Create a :class:`Channels` instance from pairs of LJH files.
 
@@ -416,6 +488,14 @@ class Channels:
                 the file path to a pulse LJH file and its corresponding noise LJH file.
             description (str):
                 A human-readable description for the resulting Channels object.
+            use_cache : bool, optional
+                Load from an existing `.ipc` cache file next to the LJH if one is present and up to date,
+                by default True.
+            generate_cache : bool, optional
+                Write a `.ipc` cache file next to the LJH after reading, by default False.
+            load_pulses : bool, optional
+                Whether to load the heavy pulse array for each channel. Set to False for lazy loading,
+                by default True.
 
         Returns:
             Channels:
@@ -441,7 +521,9 @@ class Channels:
         """
         channels: dict[int, Channel] = {}
         for pulse_path, noise_path in pulse_noise_pairs:
-            channel = Channel.from_ljh(pulse_path, noise_path)
+            channel = Channel.from_ljh(
+                pulse_path, noise_path, use_cache=use_cache, generate_cache=generate_cache, load_pulses=load_pulses
+            )
             assert channel.header.ch_num not in channels.keys()
             channels[channel.header.ch_num] = channel
         return cls(channels, description)
@@ -463,8 +545,32 @@ class Channels:
         limit: int | None = None,
         exclude_ch_nums: list[int] | None = None,
         include_ch_nums: list[int] | None = None,
+        use_cache: bool = True,
+        generate_cache: bool = False,
+        load_pulses: bool = True,
     ) -> "Channels":
-        """Create an instance from a directory of LJH files."""
+        """Create an instance from a directory of LJH files.
+
+        Parameters
+        ----------
+        pulse_folder : str | Path
+            Directory containing the pulse LJH files.
+        noise_folder : str | Path | None, optional
+            Directory containing the noise LJH files. If None, channels are loaded without noise, by default None.
+        limit : int | None, optional
+            Maximum number of channel pairs to load, by default None (load all).
+        exclude_ch_nums : list[int] | None, optional
+            Channel numbers to skip, by default None.
+        include_ch_nums : list[int] | None, optional
+            If given, only load these channel numbers, by default None (load all).
+        use_cache : bool, optional
+            Load from an existing `.ipc` cache file next to the LJH if one is present and up to date,
+            by default True.
+        generate_cache : bool, optional
+            Write a `.ipc` cache file next to the LJH after reading, by default False.
+        load_pulses : bool, optional
+            Whether to load the heavy pulse array. Set to False for lazy loading, by default True.
+        """
         assert os.path.isdir(pulse_folder), f"{pulse_folder=} {noise_folder=}"
         pulse_folder = str(pulse_folder)
         if exclude_ch_nums is None:
@@ -483,7 +589,7 @@ class Channels:
         description = f"from_ljh_folder {pulse_folder=} {noise_folder=}"
         print(f"{description}")
         print(f"   from_ljh_folder has {len(pairs)} pairs")
-        data = cls.from_ljh_path_pairs(pairs, description)
+        data = cls.from_ljh_path_pairs(pairs, description, use_cache=use_cache, generate_cache=generate_cache, load_pulses=load_pulses)
         print(f"   and the Channels obj has {len(data.channels)} pairs")
         return data
 
@@ -680,7 +786,11 @@ class Channels:
             ch = self.channels[ch_num]
             other_ch = other_data.channels[ch_num]
             combined_df = mass2.core.misc.concat_dfs_with_concat_state(ch.df, other_ch.df)
-            new_ch = ch.with_replacement_df(combined_df)
+            my_sources = getattr(ch, "data_sources", [str(ch.header.data_source)])
+            other_sources = getattr(other_ch, "data_sources", [str(other_ch.header.data_source)])
+            combined_sources = list(dict.fromkeys(my_sources + other_sources))
+            combined_npulses = len(combined_df)
+            new_ch = dataclasses.replace(ch, df=combined_df, data_sources=combined_sources, npulses=combined_npulses)
             new_channels[ch_num] = new_ch
         return mass2.Channels(new_channels, self.description + other_data.description)
 
@@ -712,7 +822,10 @@ class Channels:
         """
         base = next(iter(constituents.values()))
         chdict: dict[int, mass2.Channel] = {}
-        for chnum in base.channels.keys():
+        common_chnums = set(base.channels.keys())
+        for v in constituents.values():
+            common_chnums.intersection_update(v.channels.keys())
+        for chnum in common_chnums:
             d = {k: v.channels[chnum] for (k, v) in constituents.items()}
             chdict[chnum] = mass2.Channel.combine_channels(sourcename=sourcename, constituents=d)
         return Channels(chdict, base.description)
@@ -748,21 +861,31 @@ class Channels:
         return Channels(channels, description)
 
     def save_analysis(
-        self, zip_path: Path | str, overwrite: bool = False, trim_debug: bool = False, trim_timestamp_and_subframecount: bool = False
+        self,
+        zip_path: Path | str,
+        overwrite: bool = False,
+        trim_debug: bool = False,
+        trim_timestamp_and_subframecount: bool = False,
+        trim_pulse: bool = True,
     ) -> None:
-        """Save an analysis-in-progress completely to a zip file, only tested for ljh backed channels so far
+        """Save an analysis-in-progress completely to a zip file.
 
         Parameters
         ----------
-        path : Path | str
-            Directory to save work in. If it doesn't exist, its parent should.
+        zip_path : Path | str
+            Path to the output zip file. A `.zip` extension is added automatically if absent.
         overwrite : bool, optional
-            If `path` exists, whether to overwrite it, by default False
+            Whether to overwrite an existing file, by default False.
         trim_debug : bool, optional
-            Whether to make save file smaller (potentially) at the cost of breaking some debugging plots, by default False
-        trim_timestamp_and_subframecount: bool, optional
-            Whether to make the save file smaller at the cost of reduced information avaialble when the ljh files are
-            not available, eg when loading on another computer.
+            Drop debug-only data from each step to reduce file size, at the cost of breaking some
+            debugging plots, by default False.
+        trim_timestamp_and_subframecount : bool, optional
+            Drop the timestamp and subframecount columns from the saved parquet, by default False.
+            Reduces file size but those columns cannot be recovered on load if the original LJH files
+            are unavailable.
+        trim_pulse : bool, optional
+            Drop the pulse column from the saved parquet, by default True. Set to False to embed
+            pulse data in the archive so the analysis can be loaded without the original LJH files.
         """
         zip_path = pathlib.Path(zip_path)
         if zip_path.suffix != ".zip":
@@ -790,10 +913,11 @@ class Channels:
                 A copy of `ch` amenable to pickling with the dataframe and dataframe history removed and with trimmed steps.
             """
             # Don't store the memmapped LJH pulse info (if present) in the Parquet file
+            df = ch.df
             if trim_timestamp_and_subframecount:
-                df = ch.df.drop("pulse", "timestamp", "subframecount", strict=False)
-            else:
-                df = ch.df.drop("pulse", strict=False)
+                df = df.drop("timestamp", "subframecount", strict=False)
+            if trim_pulse:
+                df = df.drop("pulse", strict=False)
             buffer = io.BytesIO()
             df.write_parquet(buffer)
             zf.writestr(parquet_path, buffer.getvalue())
@@ -801,7 +925,8 @@ class Channels:
                 steps = ch.steps.trim_debug_info()
             else:
                 steps = ch.steps
-            return dataclasses.replace(ch, df=pl.DataFrame(), df_history=[], noise=None, steps=steps)
+            safe_noise = ch.noise.drop_pulse() if ch.noise else None
+            return dataclasses.replace(ch, df=pl.DataFrame(), df_history=[], noise=safe_noise, steps=steps)
 
         with ZipFile(str(zip_path), "w") as zf:
             channels = {}
@@ -818,43 +943,48 @@ class Channels:
             zf.writestr(pickle_file, dill.dumps(data))
 
     @staticmethod
-    def load_analysis(path: Path | str) -> "Channels":
+    def load_analysis(path: Path | str, load_pulse: bool = True) -> "Channels":
         """Load an analysis-in-progress from a zipfile
 
         Parameters
         ----------
         path : Path | str
             Zipfile that work was saved in.
+        load_pulse : bool, optional
+            Whether to rehydrate the 'pulse' column from raw LJH/OFF files where possible, by default True.
+            Note: only the pulse column is restored from LJH; archives saved with
+            ``trim_timestamp_and_subframecount=True`` will remain without those columns after loading.
         """
         path = pathlib.Path(path)
         path.exists() and path.is_file()
 
         def _restore_dataframe(ch: Channel, df: pl.DataFrame) -> Channel:
             """Take a channel and replace its dataframe with the given one, loaded from a parquet file
-
             Parameters
             ----------
             ch : Channel
                 A channel, loaded from a pickle file, with an empty dataframe
             df : DataFrame
                 A replacement dataframe for the existing one (typically, the existing one is empty)
-
             Returns
             -------
             Channel
                 The Channel `ch` but with `ch.df` updated, including any raw data backed by an LJH file
             """
-            # If this channel was based on an LJH file, restore columns from the LJH file to the dataframe.
-            if ch.header.data_source is not None:
-                ljh_path = ch.header.data_source
-                if ljh_path.endswith(".ljh") or ljh_path.endswith(".noi"):
-                    ljh_backed_chan = Channel.from_ljh(ljh_path)
-                    df = df.with_columns(ljh_backed_chan.df)
             # df_history is needed for some debug plots to work. This version has strictly more columns than required
             # at each history point. TODO: We could use the steps inputs and outputs to trim the appropriate columns.
             # For getting started, though, it's easier just to let each dataframe in history equal the final dataframe.
-            df_history = [df] * len(ch.steps)
-            return dataclasses.replace(ch, df=df, df_history=df_history)
+            clean_df = df.drop("pulse", strict=False)
+            df_history = [clean_df] * len(ch.steps)
+            if "pulse" in df.columns:
+                # Pulse was explicitly embedded in the archive (trim_pulse=False at save time);
+                # use it directly so the analysis works without the original LJH files.
+                ch = dataclasses.replace(ch, df=df, df_history=df_history)
+            else:
+                ch = dataclasses.replace(ch, df=clean_df, df_history=df_history)
+                if load_pulse:
+                    ch = ch.load_pulse()
+            return ch
 
         with ZipFile(path, "r") as zf:
             pickle_file = "data_all.pkl"

--- a/mass2/core/misc.py
+++ b/mass2/core/misc.py
@@ -186,6 +186,17 @@ def merge_dicts_ordered_by_keys(dict1: dict[int, Any], dict2: dict[int, Any]) ->
 def concat_dfs_with_concat_state(df1: pl.DataFrame, df2: pl.DataFrame, concat_state_col: str = "concat_state") -> pl.DataFrame:
     """Concatenate two DataFrames vertically, adding a column `concat_state` (or named according to `concat_state_col`)
     to indicate which DataFrame each row came from."""
+
+    cat_cols = list(
+        dict.fromkeys(
+            [col for col, dtype in df1.schema.items() if dtype == pl.Categorical]
+            + [col for col, dtype in df2.schema.items() if dtype == pl.Categorical]
+        )
+    )
+    if cat_cols:
+        df1 = df1.with_columns([pl.col(c).cast(pl.String) for c in cat_cols if c in df1.columns])
+        df2 = df2.with_columns([pl.col(c).cast(pl.String) for c in cat_cols if c in df2.columns])
+
     if concat_state_col in df1.columns:
         # Continue incrementing from the last known concat_state
         max_state = df1[concat_state_col][-1]
@@ -196,6 +207,10 @@ def concat_dfs_with_concat_state(df1: pl.DataFrame, df2: pl.DataFrame, concat_st
         df2 = df2.with_columns(pl.lit(1).alias(concat_state_col))
 
     df_out = pl.concat([df1, df2], how="vertical")
+
+    if cat_cols:
+        df_out = df_out.with_columns([pl.col(c).cast(pl.Categorical) for c in cat_cols])
+
     return df_out
 
 

--- a/mass2/core/noise_channel.py
+++ b/mass2/core/noise_channel.py
@@ -2,6 +2,8 @@
 Hold a class to represent a channel with noise data only, and to analyze its noise characteristics.
 """
 
+import dataclasses
+import warnings
 from typing import Any
 from numpy.typing import NDArray
 from pathlib import Path
@@ -118,9 +120,111 @@ class NoiseChannel:
         return False
 
     @classmethod
-    def from_ljh(cls, path: str | Path) -> "NoiseChannel":
+    def _load_from_ipc_cache(
+        cls,
+        data_ipc_path: Path,
+        header_ipc_path: Path,
+        path: "str | Path",
+        load_pulses: bool,
+    ) -> "NoiseChannel":
+        if load_pulses:
+            df = pl.read_ipc(data_ipc_path, memory_map=True)
+        else:
+            df = pl.scan_ipc(data_ipc_path).select(pl.exclude("pulse")).collect()
+        header_df = pl.read_ipc(header_ipc_path)
+        if "source_file" not in df.columns:
+            df = df.with_columns(
+                pl.lit(str(path)).alias("source_file").cast(pl.Categorical),
+                pl.int_range(0, len(df), dtype=pl.Int64).alias("source_id"),
+            )
+        elif "source_id" not in df.columns:
+            df = df.with_columns(pl.int_range(0, len(df), dtype=pl.Int64).alias("source_id"))
+        return cls(df, header_df, header_df["Timebase"][0])
+
+    @classmethod
+    def from_ljh(
+        cls,
+        path: str | Path,
+        keep_posix_usec: bool = False,
+        use_cache: bool = True,
+        generate_cache: bool = False,
+        load_pulses: bool = True,
+    ) -> "NoiseChannel":
         """Create a NoiseChannel by loading data from the given LJH file path."""
+        path_obj = Path(path)
+        data_ipc_path = path_obj.with_suffix(".ipc")
+        header_ipc_path = path_obj.with_suffix(".header.ipc")
+        cache_exists = data_ipc_path.exists() and header_ipc_path.exists()
+        cache_is_valid = False
+        if cache_exists:
+            if path_obj.stat().st_mtime < data_ipc_path.stat().st_mtime:
+                cache_is_valid = True
+            else:
+                print(f"Cache for {path_obj.name} is out of date. Regenerating...")
+        if use_cache and cache_is_valid:
+            try:
+                return cls._load_from_ipc_cache(data_ipc_path, header_ipc_path, path, load_pulses)
+            except Exception as e:
+                print(f"Warning: Corrupted cache detected for {path_obj.name} ({e}). Falling back to raw LJH.")
         ljh = mass2.LJHFile.open(path)
-        df, header_df = ljh.to_polars()
-        noise_channel = cls(df, header_df, header_df["Timebase"][0])
-        return noise_channel
+        df, header_df = ljh.to_polars(keep_posix_usec)
+        if "source_file" not in df.columns:
+            df = df.with_columns(
+                pl.lit(str(path)).alias("source_file").cast(pl.Categorical),
+                pl.int_range(0, len(df), dtype=pl.Int64).alias("source_id"),
+            )
+        elif "source_id" not in df.columns:
+            df = df.with_columns(pl.int_range(0, len(df), dtype=pl.Int64).alias("source_id"))
+        if generate_cache:
+            print(f"Generating IPC cache for {path_obj.name}...")
+            tmp_data_path = Path(str(data_ipc_path) + ".tmp")
+            tmp_header_path = Path(str(header_ipc_path) + ".tmp")
+            df.write_ipc(tmp_data_path, compression="uncompressed")
+            header_df.write_ipc(tmp_header_path, compression="uncompressed")
+            tmp_data_path.replace(data_ipc_path)
+            tmp_header_path.replace(header_ipc_path)
+            if use_cache:
+                del df, header_df
+                if load_pulses:
+                    df = pl.read_ipc(data_ipc_path, memory_map=True)
+                else:
+                    df = pl.scan_ipc(data_ipc_path).select(pl.exclude("pulse")).collect()
+                header_df = pl.read_ipc(header_ipc_path)
+        if not load_pulses and "pulse" in df.columns:
+            df = df.drop("pulse", strict=False)
+        return cls(df, header_df, header_df["Timebase"][0])
+
+    def load_pulse(self, use_cache: bool = True, generate_cache: bool = False) -> "NoiseChannel":
+        """Rehydrate the noise pulse column lazily."""
+        if "pulse" in self.df.columns:
+            return self
+        src = None
+        if "source_file" in self.df.columns and len(self.df) > 0:
+            src = self.df["source_file"][0]
+        elif "Filename" in self.header_df.columns and len(self.header_df) > 0:
+            src = self.header_df["Filename"][0]
+        elif "filename" in self.header_df.columns and len(self.header_df) > 0:
+            src = self.header_df["filename"][0]
+        if src is not None and isinstance(src, str):
+            if src.endswith(".ljh") or src.endswith(".noi"):
+                temp_chan = self.__class__.from_ljh(src, use_cache=use_cache, generate_cache=generate_cache, load_pulses=True)
+                if "source_id" in self.df.columns:
+                    source_ids = self.df["source_id"].to_numpy()
+                    pulse_series = temp_chan.df["pulse"].gather(source_ids)
+                    return dataclasses.replace(self, df=self.df.with_columns(pulse_series))
+                if len(self.df) == len(temp_chan.df):
+                    return dataclasses.replace(self, df=self.df.with_columns(temp_chan.df["pulse"]))
+                warnings.warn(
+                    "NoiseChannel has different length than source file and no source_id; "
+                    "cannot splice pulse column. Returning fresh channel (computed columns lost).",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                return dataclasses.replace(self, df=temp_chan.df)
+        return self
+
+    def drop_pulse(self) -> "NoiseChannel":
+        """Drop the heavy pulse array from RAM."""
+        if "pulse" in self.df.columns:
+            return dataclasses.replace(self, df=self.df.drop("pulse", strict=False))
+        return self

--- a/mass2/core/rough_cal.py
+++ b/mass2/core/rough_cal.py
@@ -56,7 +56,8 @@ def rank_3peak_assignments(
     df1 = df1.filter((pl.col("e0") < pl.col("e1")).and_(pl.col("ph0") < pl.col("ph1")))
     # 2) the gain slope must be negative
     df1 = (
-        df1.with_columns(gain1=pl.col("ph1") / pl.col("e1"))
+        df1
+        .with_columns(gain1=pl.col("ph1") / pl.col("e1"))
         .with_columns(gain_slope=(pl.col("gain1") - pl.col("gain0")) / (pl.col("ph1") - pl.col("ph0")))
         .filter(pl.col("gain_slope") < 0)
     )

--- a/mass2/core/truebq_bin.py
+++ b/mass2/core/truebq_bin.py
@@ -81,7 +81,8 @@ class TriggerResult:
 
         # trigger indices (raw) → restrict to plotted window → convert to decimated indices
         trig_inds_raw = (
-            pl.DataFrame({"trig_inds": self.trig_inds})
+            pl
+            .DataFrame({"trig_inds": self.trig_inds})
             .filter(pl.col("trig_inds").is_between(raw_start, raw_stop))
             .to_series()
             .to_numpy()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,10 @@ exclude = [
     "mass2/core/mass2main.py",
     "mass2/core/mass2notebook.py"
     ]
+disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = ["mass2", "mass2.*", "mass2.*.*", "mass2.*.*.*"]
 disallow_untyped_defs = true
 
 [tool.interrogate]

--- a/tests/core/test_channels.py
+++ b/tests/core/test_channels.py
@@ -1,5 +1,6 @@
 import numpy as np
 import os
+import shutil
 import pytest
 import polars as pl
 from polars.testing import assert_frame_equal
@@ -54,7 +55,8 @@ def test_with_columns():
     rt = ch.df["pulse_rms"].to_numpy() ** 0.5
     df = pl.DataFrame({"F": pl.Series(rt), "G": pl.Series(rt)})
     ch = (
-        ch.with_columns(A=pl.col("pulse_rms").sqrt(), B=pl.col("pulse_rms") ** 0.5, C=rt)
+        ch
+        .with_columns(A=pl.col("pulse_rms").sqrt(), B=pl.col("pulse_rms") ** 0.5, C=rt)
         .with_columns(pl.col("pulse_rms").sqrt().alias("D"), pl.col("pulse_rms").sqrt().alias("E"))
         .with_columns(df)
     )
@@ -185,6 +187,9 @@ def test_follow_mass_filtering_rst():  # noqa: PLR0914
     frametime_s = 1e-5
     df_noise = pl.DataFrame({"pulse": noise_traces})
     noise_ch = mass2.NoiseChannel(df_noise, header_df, frametime_s)
+    noiseresult = noise_ch.spectrum()
+    noiseresult.autocorr_vec[:] = 0
+    noiseresult.autocorr_vec[0] = sigma_noise**2
     header = mass2.ChannelHeader(
         "dummy for test",
         data_source=None,
@@ -196,9 +201,17 @@ def test_follow_mass_filtering_rst():  # noqa: PLR0914
     )
     df = pl.DataFrame({"pulse": pulse_traces})
     ch = mass2.Channel(df, header, npulses=npulses, noise=noise_ch)
-    ch = ch.filter5lag()
-    step: mass2.core.OptimalFilterStep = ch.steps[-1]
-    assert isinstance(step, mass2.core.OptimalFilterStep)
+    step = mass2.core.filter_steps.OptimalFilterStep(
+        inputs=["pulse"],
+        output=["5lagx", "5lagy"],
+        good_expr=ch.good_expr,
+        use_expr=pl.lit(True),
+        filter=mass_filter,
+        spectrum=noiseresult,
+        filter_maker=maker,
+        transform_raw=ch.transform_raw,
+    )
+    ch = ch.with_step(step)
     filter: mass2.core.Filter = step.filter
     assert filter.predicted_v_over_dv == pytest.approx(mass_filter.predicted_v_over_dv, rel=1e-2)
     # test that the mass normaliztion in place
@@ -214,6 +227,63 @@ def test_follow_mass_filtering_rst():  # noqa: PLR0914
     assert psd is not None
     assert isinstance(psd[1], np.ndarray)
     assert isinstance(ch.last_v_over_dv, float)
+
+
+def test_filter5lag_uses_noise_channel():
+    """Test that filter5lag() correctly extracts the noise spectrum from the NoiseChannel.
+
+    test_follow_mass_filtering_rst verifies the filter math with an exact spectrum.
+    This test exercises the full code path: filter5lag() -> noise_ch.spectrum() ->
+    FilterMaker -> OptimalFilterStep, using enough noise traces (2000) for the
+    empirical covariance estimate to be close to the theoretical white-noise value.
+    """
+    rng = np.random.default_rng(7)
+    n = 504
+    Maxsignal = 1000.0
+    sigma_noise = 1.0
+    tau = [0.05, 0.25]
+    t = np.linspace(-1, 1, n)
+    npre = int((t < 0).sum())
+    signal = np.exp(-t / tau[1]) - np.exp(-t / tau[0])
+    signal[t <= 0] = 0
+    signal *= Maxsignal / signal.max()
+
+    # Theoretical reference filter
+    noise_covar = np.zeros(n)
+    noise_covar[0] = sigma_noise**2
+    theoretical_filter = mass2.core.FilterMaker(signal, npre, noise_covar, peak=Maxsignal).compute_5lag()
+
+    # 2000 noise traces: enough for the empirical autocorrelation to approximate white noise
+    noise_traces = rng.standard_normal((2000, n)) * sigma_noise
+    header_df = pl.DataFrame({"continuous": [True]})
+    frametime_s = 1e-5
+    noise_ch = mass2.NoiseChannel(pl.DataFrame({"pulse": noise_traces}), header_df, frametime_s)
+
+    npulses = 250
+    pulse_traces = np.tile(signal, (npulses, 1)) + rng.standard_normal((npulses, n)) * sigma_noise
+    header = mass2.ChannelHeader(
+        "dummy for noise test",
+        data_source=None,
+        ch_num=0,
+        frametime_s=frametime_s,
+        n_presamples=npre,
+        n_samples=n,
+        df=header_df,
+    )
+    ch = mass2.Channel(pl.DataFrame({"pulse": pulse_traces}), header, npulses=npulses, noise=noise_ch)
+    ch = ch.filter5lag()
+
+    step: mass2.core.OptimalFilterStep = ch.steps[-1]
+    assert isinstance(step, mass2.core.OptimalFilterStep)
+
+    # The empirically-derived filter should be close to the theoretical optimum (10% tolerance)
+    assert step.filter.predicted_v_over_dv == pytest.approx(theoretical_filter.predicted_v_over_dv, rel=0.10)
+
+    # Verify the noise autocorrelation stored on the channel is approximately white
+    autocorr = ch.last_noise_autocorrelation
+    assert isinstance(autocorr, np.ndarray)
+    assert autocorr[0] == pytest.approx(sigma_noise**2, rel=0.10)
+    assert np.mean(np.abs(autocorr[1:])) == pytest.approx(0, abs=0.05 * sigma_noise**2)
 
 
 def test_noise_autocorr():
@@ -459,7 +529,8 @@ def test_steps():
     # Perform 5 offical Recipe: summarize, filter, a pointless "squareme" step, drift correction, and another pointless one.
     def _do_steps(ch: mass2.Channel) -> mass2.Channel:
         return (
-            ch.summarize_pulses()
+            ch
+            .summarize_pulses()
             .with_good_expr_pretrig_rms_and_postpeak_deriv(8, 8)
             .filter5lag(f_3db=10000)
             .with_column_map_step("pretrig_rms", "pointless_pretrig_meansq", squareme)
@@ -526,7 +597,8 @@ def test_save_analysis(tmpdir):
     savefile = dir / "test_save"
     actual_savefile = savefile.with_suffix(".zip")
     data.save_analysis(savefile)
-    data2 = mass2.Channels.load_analysis(actual_savefile)
+    # load_pulse=False: dummy channel has no LJH backing, so pulse cannot be restored.
+    data2 = mass2.Channels.load_analysis(actual_savefile, load_pulse=False)
 
     # Verify that the good channel's data is restored
     # It's a dummy channel, not ljh-backed, so the pulse data will be gone.
@@ -621,3 +693,341 @@ def test_ch_from_numpy2():
     for i in range(ch.npulses):
         pulse = data.ch0.df["pulse"][i].to_numpy()
         assert np.all(pulse < 5000) and np.all(pulse > -5000)
+
+
+def test_drop_pulse():
+    """Channel.drop_pulse() removes the pulse column and propagates to noise; is idempotent."""
+    ch = dummy_channel().summarize_pulses()  # ensure non-pulse columns exist alongside pulse
+    assert "pulse" in ch.df.columns
+    assert "pulse" in ch.noise.df.columns
+
+    ch_dropped = ch.drop_pulse()
+    assert "pulse" not in ch_dropped.df.columns
+    assert "pulse" not in ch_dropped.noise.df.columns
+    # npulses must reflect row count of the surviving df (has non-pulse columns, so row count preserved)
+    assert ch_dropped.npulses == ch.npulses
+
+    # Calling again must not raise
+    ch_dropped2 = ch_dropped.drop_pulse()
+    assert "pulse" not in ch_dropped2.df.columns
+
+
+def test_noise_channel_drop_pulse():
+    """NoiseChannel.drop_pulse() removes the pulse column and is idempotent."""
+    rng = np.random.default_rng(1)
+    noise_traces = rng.standard_normal((10, 20)).astype(np.float32)
+    noise_ch = mass2.NoiseChannel(pl.DataFrame({"pulse": noise_traces}), pl.DataFrame(), 1e-5)
+    assert "pulse" in noise_ch.df.columns
+
+    dropped = noise_ch.drop_pulse()
+    assert "pulse" not in dropped.df.columns
+    assert "pulse" not in dropped.drop_pulse().df.columns
+
+
+def test_with_replacement_df_updates_npulses():
+    """with_replacement_df() must update npulses to match the new DataFrame length."""
+    ch = dummy_channel(npulses=100)
+    new_df = ch.df.head(40)
+    ch2 = ch.with_replacement_df(new_df)
+    assert ch2.npulses == 40
+    assert len(ch2.df) == 40
+
+
+def test_with_step_drops_pulse_from_history():
+    """with_step() must store the previous df without the pulse column in df_history."""
+    ch = dummy_channel()
+    ch = ch.with_columns(extra_col=np.arange(len(ch.df)))
+    assert ch.df_history == []
+
+    ch2 = ch.summarize_pulses()
+
+    assert len(ch2.df_history) == 1
+    assert "pulse" not in ch2.df_history[0].columns
+    assert "extra_col" in ch2.df_history[0].columns
+    # Current df keeps the pulse column
+    assert "pulse" in ch2.df.columns
+
+
+def test_concat_ch_merges_data_sources():
+    """concat_ch() must merge and deduplicate data_sources in insertion order."""
+    ch1 = dataclasses.replace(dummy_channel(), data_sources=["file_a.ljh"])
+    ch2 = dataclasses.replace(dummy_channel(), data_sources=["file_b.ljh"])
+    ch3 = dataclasses.replace(dummy_channel(), data_sources=["file_a.ljh", "file_c.ljh"])
+
+    combined = ch1.concat_ch(ch2)
+    assert combined.data_sources == ["file_a.ljh", "file_b.ljh"]
+    assert combined.npulses == ch1.npulses + ch2.npulses
+
+    # file_a.ljh appears in both — deduplicated, file_c.ljh appended
+    combined2 = ch1.concat_ch(ch3)
+    assert combined2.data_sources == ["file_a.ljh", "file_c.ljh"]
+
+
+def test_channel_combine_channels_tracks_data_sources():
+    """Channel.combine_channels() must collect data_sources from all constituents."""
+    ch1 = dataclasses.replace(dummy_channel(), data_sources=["file_a.ljh"])
+    ch2 = dataclasses.replace(dummy_channel(), data_sources=["file_b.ljh"])
+
+    combined = mass2.Channel.combine_channels("run", {"run1": ch1, "run2": ch2})
+    assert "file_a.ljh" in combined.data_sources
+    assert "file_b.ljh" in combined.data_sources
+
+
+def test_channels_combine_channels_intersection():
+    """Channels.combine_channels() must only keep channels present in ALL constituents."""
+    ch0 = dummy_channel(ch_num=0)
+    ch1 = dummy_channel(ch_num=1)
+    ch2 = dummy_channel(ch_num=2)
+
+    data_a = mass2.Channels({0: ch0, 1: ch1}, description="a")
+    data_b = mass2.Channels({1: ch1, 2: ch2}, description="b")
+
+    combined = mass2.Channels.combine_channels("run", {"a": data_a, "b": data_b})
+    # Channel 1 is the only one present in both
+    assert set(combined.channels.keys()) == {1}
+
+
+def test_concat_dfs_with_concat_state_categorical():
+    """concat_dfs_with_concat_state must preserve Categorical dtype through the concat."""
+    df1 = pl.DataFrame({
+        "source_file": pl.Series(["a.ljh", "a.ljh"], dtype=pl.Categorical),
+        "val": [1, 2],
+    })
+    df2 = pl.DataFrame({
+        "source_file": pl.Series(["b.ljh", "b.ljh"], dtype=pl.Categorical),
+        "val": [3, 4],
+    })
+
+    result = mass2.core.misc.concat_dfs_with_concat_state(df1, df2)
+
+    assert result.shape == (4, 3)  # source_file, val, concat_state
+    assert result["source_file"].dtype == pl.Categorical
+    assert result["source_file"].cast(pl.String).to_list() == ["a.ljh", "a.ljh", "b.ljh", "b.ljh"]
+
+
+def test_save_analysis_trim_pulse_false(tmpdir):
+    """save_analysis(trim_pulse=False) embeds pulse in the archive so it survives load without LJH files."""
+    ch = dummy_channel(ch_num=0).summarize_pulses()
+    original_pulse = np.array(ch.df["pulse"][0])
+    data = mass2.Channels({0: ch}, description="test")
+
+    savefile = pathlib.Path(tmpdir) / "embedded_pulse"
+    actual_savefile = savefile.with_suffix(".zip")
+    data.save_analysis(savefile, trim_pulse=False)
+
+    data2 = mass2.Channels.load_analysis(actual_savefile)
+    restored_ch = data2.channels[0]
+
+    assert "pulse" in restored_ch.df.columns
+    assert len(restored_ch.df) == len(ch.df)
+    assert np.allclose(np.array(restored_ch.df["pulse"][0]), original_pulse)
+
+
+def test_load_analysis_load_pulse_false(tmpdir):
+    """load_analysis(load_pulse=False) returns channels without pulse when the archive has none."""
+    ch = dummy_channel(ch_num=0).summarize_pulses()
+    data = mass2.Channels({0: ch}, description="test")
+
+    savefile = pathlib.Path(tmpdir) / "no_pulse"
+    actual_savefile = savefile.with_suffix(".zip")
+    data.save_analysis(savefile)  # default trim_pulse=True
+
+    data2 = mass2.Channels.load_analysis(actual_savefile, load_pulse=False)
+    restored_ch = data2.channels[0]
+
+    assert "pulse" not in restored_ch.df.columns
+    assert "pretrig_mean" in restored_ch.df.columns
+
+
+def test_channel_load_pulse_drop_pulse_ljh():
+    """Channel.load_pulse() reconstructs the pulse column from the source LJH file."""
+    p = pulsedata.pulse_noise_ljh_pairs["20230626"]
+    pulse_path = str(p.pulse_folder / "20230626_run0001_chan4109.ljh")
+    noise_path = str(p.noise_folder / "20230626_run0000_chan4109.ljh")
+
+    ch_full = mass2.Channel.from_ljh(pulse_path, noise_path)
+    assert "pulse" in ch_full.df.columns
+    assert "source_file" in ch_full.df.columns
+
+    ch_no_pulse = mass2.Channel.from_ljh(pulse_path, noise_path, load_pulses=False)
+    assert "pulse" not in ch_no_pulse.df.columns
+    assert "source_file" in ch_no_pulse.df.columns
+    assert "source_id" in ch_no_pulse.df.columns
+    assert ch_no_pulse.npulses == ch_full.npulses
+
+    ch_restored = ch_no_pulse.load_pulse()
+    assert "pulse" in ch_restored.df.columns
+    assert len(ch_restored.df) == len(ch_full.df)
+    assert np.allclose(ch_full.df["pulse"].to_numpy(), ch_restored.df["pulse"].to_numpy())
+
+
+def test_noise_channel_load_pulse_ljh():
+    """NoiseChannel.load_pulse() rehydrates pulse from the source LJH file."""
+    p = pulsedata.pulse_noise_ljh_pairs["20230626"]
+    noise_path = str(p.noise_folder / "20230626_run0000_chan4109.ljh")
+
+    noise_full = mass2.NoiseChannel.from_ljh(noise_path)
+    assert "pulse" in noise_full.df.columns
+
+    noise_no_pulse = mass2.NoiseChannel.from_ljh(noise_path, load_pulses=False)
+    assert "pulse" not in noise_no_pulse.df.columns
+    assert "source_file" in noise_no_pulse.df.columns
+    assert len(noise_no_pulse.df) == len(noise_full.df)
+
+    noise_restored = noise_no_pulse.load_pulse()
+    assert "pulse" in noise_restored.df.columns
+    assert len(noise_restored.df) == len(noise_full.df)
+
+
+def test_requires_pulse_transparent():
+    """@requires_pulse lets decorated methods give identical results with or without a pre-loaded pulse."""
+    p = pulsedata.pulse_noise_ljh_pairs["20230626"]
+    pulse_path = str(p.pulse_folder / "20230626_run0001_chan4109.ljh")
+    noise_path = str(p.noise_folder / "20230626_run0000_chan4109.ljh")
+
+    ch_with = mass2.Channel.from_ljh(pulse_path, noise_path)
+    # drop_pulse preserves source_file/source_id so load_pulse() can rehydrate
+    ch_without = ch_with.drop_pulse()
+    assert "pulse" not in ch_without.df.columns
+
+    # summarize_pulses returns a Channel — decorator drops pulse when it was absent
+    ch_sum_with = ch_with.summarize_pulses()
+    ch_sum_without = ch_without.summarize_pulses()
+
+    assert "pulse" not in ch_sum_without.df.columns
+    for col in ("pretrig_mean", "pretrig_rms", "pulse_rms", "postpeak_deriv"):
+        assert col in ch_sum_with.df.columns
+        assert col in ch_sum_without.df.columns
+        assert np.allclose(
+            ch_sum_with.df[col].to_numpy(),
+            ch_sum_without.df[col].to_numpy(),
+        )
+
+    # compute_average_pulse returns NDArray — pulse is NOT stripped from the return value
+    avg_with = ch_with.compute_average_pulse()
+    avg_without = ch_without.compute_average_pulse()
+    assert isinstance(avg_with, np.ndarray)
+    assert isinstance(avg_without, np.ndarray)
+    assert np.allclose(avg_with, avg_without)
+
+
+def test_ipc_cache_generation(tmp_path):
+    """from_ljh(generate_cache=True) writes .ipc files; use_cache=True reads back identical data."""
+    p = pulsedata.pulse_noise_ljh_pairs["20230626"]
+    src = p.pulse_folder / "20230626_run0001_chan4109.ljh"
+    dst = tmp_path / src.name
+    shutil.copy(src, dst)
+
+    ch_ref = mass2.Channel.from_ljh(str(dst), use_cache=False, generate_cache=True)
+    ipc_path = dst.with_suffix(".ipc")
+    header_ipc_path = dst.with_suffix(".header.ipc")
+    assert ipc_path.exists()
+    assert header_ipc_path.exists()
+
+    ch_cached = mass2.Channel.from_ljh(str(dst), use_cache=True, generate_cache=False)
+    assert "pulse" in ch_cached.df.columns
+    assert len(ch_cached.df) == len(ch_ref.df)
+    assert np.allclose(ch_cached.df["pulse"].to_numpy(), ch_ref.df["pulse"].to_numpy())
+
+
+def test_ipc_cache_load_pulses_false(tmp_path):
+    """from_ljh with use_cache=True and load_pulses=False reads from cache but drops pulse."""
+    p = pulsedata.pulse_noise_ljh_pairs["20230626"]
+    src = p.pulse_folder / "20230626_run0001_chan4109.ljh"
+    dst = tmp_path / src.name
+    shutil.copy(src, dst)
+
+    ch_full = mass2.Channel.from_ljh(str(dst), use_cache=False, generate_cache=True)
+
+    ch_no_pulse = mass2.Channel.from_ljh(str(dst), use_cache=True, load_pulses=False)
+    assert "pulse" not in ch_no_pulse.df.columns
+    assert "source_file" in ch_no_pulse.df.columns
+    assert ch_no_pulse.npulses == ch_full.npulses
+
+
+def test_ipc_cache_corrupted_falls_back(tmp_path):
+    """from_ljh falls back to raw LJH and returns correct data when the cache is corrupt."""
+    p = pulsedata.pulse_noise_ljh_pairs["20230626"]
+    src = p.pulse_folder / "20230626_run0001_chan4109.ljh"
+    dst = tmp_path / src.name
+    shutil.copy(src, dst)
+    ch_ref = mass2.Channel.from_ljh(str(dst), use_cache=False)
+
+    ipc_path = dst.with_suffix(".ipc")
+    header_ipc_path = dst.with_suffix(".header.ipc")
+
+    # Write corrupt .ipc files (wrong schema — ChannelHeader construction will fail)
+    pl.DataFrame({"corrupt_col": [1]}).write_ipc(ipc_path)
+    pl.DataFrame({"corrupt_col": [1]}).write_ipc(header_ipc_path)
+    # Make cache appear newer than source so use_cache tries to read it
+    new_mtime = dst.stat().st_mtime + 10
+    os.utime(ipc_path, (new_mtime, new_mtime))
+    os.utime(header_ipc_path, (new_mtime, new_mtime))
+
+    ch = mass2.Channel.from_ljh(str(dst), use_cache=True)
+    assert len(ch.df) == len(ch_ref.df)
+    assert "pulse" in ch.df.columns
+
+
+def test_iter_pulse_batches():
+    """iter_pulse_batches() covers all pulses in order, each batch having pulse loaded."""
+    p = pulsedata.pulse_noise_ljh_pairs["20230626"]
+    pulse_path = str(p.pulse_folder / "20230626_run0001_chan4109.ljh")
+    noise_path = str(p.noise_folder / "20230626_run0000_chan4109.ljh")
+    ch = mass2.Channel.from_ljh(pulse_path, noise_path, load_pulses=False)
+    chunk_size = 2000
+
+    batches = list(ch.iter_pulse_batches(chunk_size=chunk_size))
+    assert len(batches) > 1
+    for batch in batches:
+        assert "pulse" in batch.df.columns
+        assert len(batch.df) <= chunk_size
+    assert sum(len(b.df) for b in batches) == ch.npulses
+
+
+def test_channels_map_auto_load_pulse():
+    """map(auto_load_pulse=True) retries a failed function with pulse, then drops pulse from result."""
+    p = pulsedata.pulse_noise_ljh_pairs["20230626"]
+    pulse_path = str(p.pulse_folder / "20230626_run0001_chan4109.ljh")
+    noise_path = str(p.noise_folder / "20230626_run0000_chan4109.ljh")
+
+    ch = mass2.Channel.from_ljh(pulse_path, noise_path, load_pulses=False)
+    data = mass2.Channels({4109: ch}, description="test")
+
+    def needs_pulse_directly(ch):
+        # Accesses pulse column directly — raises ColumnNotFoundError if absent
+        arr = np.vstack(ch.df["pulse"].to_list())
+        return ch.with_columns(peak_val=arr.max(axis=1))
+
+    # auto_load_pulse=True: retried with pulse loaded, result has pulse dropped
+    data_ok = data.map(needs_pulse_directly, auto_load_pulse=True)
+    assert "peak_val" in data_ok.channels[4109].df.columns
+    assert "pulse" not in data_ok.channels[4109].df.columns
+
+    # auto_load_pulse=False: function fails, channel ends up in bad_channels
+    data_bad = data.map(needs_pulse_directly, auto_load_pulse=False, allow_throw=False)
+    assert 4109 in data_bad.bad_channels
+
+
+def test_channels_map_batched():
+    """map(batched=True) processes a pulse-less channel in chunks and recombines correctly."""
+    p = pulsedata.pulse_noise_ljh_pairs["20230626"]
+    pulse_path = str(p.pulse_folder / "20230626_run0001_chan4109.ljh")
+    noise_path = str(p.noise_folder / "20230626_run0000_chan4109.ljh")
+
+    # Reference: normal processing with pulse present
+    ch_ref = mass2.Channel.from_ljh(pulse_path, noise_path).summarize_pulses()
+
+    # Batched: pulse-less channel — default chunk_size covers all pulses in one batch
+    ch_no_pulse = mass2.Channel.from_ljh(pulse_path, noise_path, load_pulses=False)
+    data = mass2.Channels({4109: ch_no_pulse}, description="test")
+    data_batched = data.map(lambda ch: ch.summarize_pulses(), batched=True)
+    ch_batched = data_batched.channels[4109]
+
+    assert len(ch_batched.df) == len(ch_ref.df)
+    assert "pretrig_mean" in ch_batched.df.columns
+    assert "pulse" not in ch_batched.df.columns
+    assert np.allclose(
+        ch_ref.df["pretrig_mean"].to_numpy(),
+        ch_batched.df["pretrig_mean"].to_numpy(),
+    )

--- a/tests/core/test_driftcorrect.py
+++ b/tests/core/test_driftcorrect.py
@@ -21,7 +21,8 @@ def test_drift_correct(N=2e5, a0=100, b0=100, slope=0.01):
 def test_time_drift_correct():
     def _do_steps(ch: mass2.Channel) -> mass2.Channel:
         return (
-            ch.summarize_pulses()
+            ch
+            .summarize_pulses()
             .with_good_expr_pretrig_rms_and_postpeak_deriv(8, 8)
             .filter5lag(f_3db=10000)
             .driftcorrect(indicator_col="pretrig_mean", uncorrected_col="5lagy", use_expr=pl.lit(True))

--- a/tests/core/test_rough_cal.py
+++ b/tests/core/test_rough_cal.py
@@ -11,7 +11,7 @@ def make_truth_ph(
     e_spurious,
     e_err_scale,
     pfit_gain_truth=np.polynomial.Polynomial([6, -1e-6, -1e-10]),
-) -> None:
+) -> tuple[np.ndarray, np.ndarray]:
     # return peak heights by inverting a quadratic gain curve and adding energy errors
     cba_truth = pfit_gain_truth.convert().coef
     assert len(cba_truth) == 3
@@ -55,10 +55,10 @@ def test_find_optimal_assignment_many() -> None:
     # ph_truth_with_err contains pulseheights of only real peaks, sorted to match the order of e
     # from all peaks (ph) find the one corresponding to energies e
     rng.shuffle(ph)  # in place shuffle
-    result = mass2.core.rough_cal.find_optimal_assignment2(ph, e, map(str, e))
+    result = mass2.core.rough_cal.find_optimal_assignment2(ph, e, list(map(str, e)))
     # test that assigned peaks match known peaks of energy e
     assert np.allclose(result.ph_assigned, ph_truth_with_err, rtol=0.001)
-    assert np.allclose([result.ph2energy(result.energy2ph(ee)) for ee in e], e)
+    assert np.allclose(np.array([result.ph2energy(result.energy2ph(ee)) for ee in e]), e)
 
 
 def test_find_optimal_assignment_1() -> None:
@@ -80,10 +80,10 @@ def test_find_optimal_assignment_1() -> None:
     # ph contains pulseheights of both real and spurious with errs
     # ph_truth_with_err contains pulseheights of only real peaks, sorted to match the order of e
     # from all peaks (ph) find the one corresponding to energies e
-    result = mass2.core.rough_cal.find_optimal_assignment2(ph, e, map(str, e))
+    result = mass2.core.rough_cal.find_optimal_assignment2(ph, e, list(map(str, e)))
     # test that assigned peaks match known peaks of energy e
     assert np.allclose(result.ph_assigned, ph_truth_with_err, rtol=0.001)
-    assert np.allclose([result.ph2energy(result.energy2ph(ee)) for ee in e], e)
+    assert np.allclose(np.array([result.ph2energy(result.energy2ph(ee)) for ee in e]), e)
 
 
 def test_find_optimal_assignment_2() -> None:
@@ -105,10 +105,10 @@ def test_find_optimal_assignment_2() -> None:
     # ph contains pulseheights of both real and spurious with errs
     # ph_truth_with_err contains pulseheights of only real peaks, sorted to match the order of e
     # from all peaks (ph) find the one corresponding to energies e
-    result = mass2.core.rough_cal.find_optimal_assignment2(ph, e, map(str, e))
+    result = mass2.core.rough_cal.find_optimal_assignment2(ph, e, list(map(str, e)))
     # test that assigned peaks match known peaks of energy e
     assert np.allclose(result.ph_assigned, ph_truth_with_err, rtol=0.001)
-    assert np.allclose([result.ph2energy(result.energy2ph(ee)) for ee in e], e)
+    assert np.allclose(np.array([result.ph2energy(result.energy2ph(ee)) for ee in e]), e)
 
 
 def test_find_optimal_assignment_3() -> None:
@@ -118,17 +118,17 @@ def test_find_optimal_assignment_3() -> None:
     # ph contains pulseheights of both real and spurious with errs
     # ph_truth_with_err contains pulseheights of only real peaks, sorted to match the order of e
     # from all peaks (ph) find the one corresponding to energies e
-    result = mass2.core.rough_cal.find_optimal_assignment2(ph, e, map(str, e))
+    result = mass2.core.rough_cal.find_optimal_assignment2(ph, e, list(map(str, e)))
     # test that assigned peaks match known peaks of energy e
     assert np.allclose(result.ph_assigned, ph_truth_with_err, rtol=0.001)
-    assert np.allclose([result.ph2energy(result.energy2ph(ee)) for ee in e], e)
+    assert np.allclose(np.array([result.ph2energy(result.energy2ph(ee)) for ee in e]), e)
 
 
 def test_rank_3peak_assignments() -> None:
     e = np.array([1000, 3000, 5000])  # energies of "real" peaks
     e_spurious = [2900, 3700, 4500]  # energies of spurious or fake peaks
     ph, ph_truth_with_err = make_truth_ph(e=e, e_spurious=e_spurious, e_err_scale=10)
-    df3peak, _dfe = mass2.core.rough_cal.rank_3peak_assignments(ph, e, map(str, e))
+    df3peak, _dfe = mass2.core.rough_cal.rank_3peak_assignments(ph, e, list(map(str, e)))
     ph_assigned_top_rank = np.array([df3peak["ph0"][0], df3peak["ph1"][0], df3peak["ph2"][0]])
     assert np.allclose(ph_truth_with_err, ph_assigned_top_rank)
 

--- a/tests/test_mkdocs.py
+++ b/tests/test_mkdocs.py
@@ -18,6 +18,7 @@ doc_paths = pathlib.Path("docs").glob("**/*.md")
 
 
 @pytest.mark.parametrize("fpath", doc_paths, ids=str)
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 def test_files_good(fpath):
     print(f"Testing {fpath}")
     check_md_file(fpath=fpath, memory=True)


### PR DESCRIPTION
This commit introduces structural changes to prevent Out-Of-Memory (OOM) 
crashes and accelerate processing times when handling massive datasets. 

Key changes include:
* Batched Processing
  - Added `batched=True` support to `Channels.map()` alongside `iter_pulse_batches()`.
* Lazy Pulse Loading:
  - Introduced `load_pulse()` and `drop_pulse()` methods, allowing the heavy 
    `pulse` column to be deferred or dropped when not actively needed.
  - Added `load_pulses` flags to initialization methods (`from_ljh`, `from_ljh_path_pairs`).
* IPC Caching Integration:
  - Added `use_cache` and `generate_cache` parameters to core loading functions 
    to reduce I/O bottlenecks during repeated initializations.
* Multi-Run Concatenation:
  - Updated `Channels.concat_data()` to safely append channel DataFrames, 
    track combined `data_sources`, and correctly calculate merged `npulses` 
    across multiple measurements.