### PR TITLE
Fix: keep PulseDataFramer in sync with DataFrame

### DIFF
--- a/mass2/core/channel.py
+++ b/mass2/core/channel.py
@@ -15,7 +15,6 @@ import pylab as plt
 from matplotlib.colors import Colormap
 from matplotlib.backend_bases import MouseEvent
 import marimo as mo
-import functools
 import numpy as np
 import time
 from pathlib import Path
@@ -69,6 +68,14 @@ class ChannelHeader:
     n_presamples: int
     n_samples: int
     df: pl.DataFrame = field(repr=False)
+    pulse_data_sources: tuple[str | None, ...] | None = field(default=None, repr=False)
+    noise_data_source: str | None = field(default=None, repr=False)
+
+    def leaf_data_sources(self) -> tuple[str | None, ...]:
+        """Leaf file paths behind this header's raw data, or `(data_source,)` if not itself a concatenation."""
+        if self.pulse_data_sources is not None:
+            return self.pulse_data_sources
+        return (self.data_source,)
 
     @classmethod
     def from_ljh_header_df(cls, df: pl.DataFrame) -> "ChannelHeader":
@@ -137,17 +144,25 @@ class Channel:
     def head(self, n: int) -> "Channel":
         "Return a new Channel, using only the first `n` pulse records (or if n<0, then all but the last abs(n))."
         df = self.df.head(n)
-        return replace(self, df=df, npulses=len(df))
+        framer = self.pulseframer.select_rows(np.arange(len(df))) if self.pulseframer is not None else None
+        return replace(self, df=df, npulses=len(df), pulseframer=framer)
 
     def tail(self, n: int) -> "Channel":
         "Return a new Channel, using only the last `n` pulse records (or if n<0, then all but the first abs(n))."
+        orig_len = len(self.df)
         df = self.df.tail(n)
-        return replace(self, df=df, npulses=len(df))
+        start = orig_len - len(df)
+        framer = self.pulseframer.select_rows(np.arange(start, orig_len)) if self.pulseframer is not None else None
+        return replace(self, df=df, npulses=len(df), pulseframer=framer)
 
     def sample(self, n: int | None, fraction: float | None = None) -> "Channel":
         "Return a new Channel, using only a random selection of `n` pulse records."
-        df = self.df.sample(n=n, fraction=fraction, with_replacement=False)
-        return replace(self, df=df, npulses=len(df))
+        df_indexed = self.df.with_row_index("__sample_idx__")
+        sampled = df_indexed.sample(n=n, fraction=fraction, with_replacement=False)
+        row_indices = sampled["__sample_idx__"].to_numpy()
+        df = sampled.drop("__sample_idx__")
+        framer = self.pulseframer.select_rows(row_indices) if self.pulseframer is not None else None
+        return replace(self, df=df, npulses=len(df), pulseframer=framer)
 
     def mo_stepplots(self) -> mo.ui.dropdown:
         """Marimo UI element to choose and display step plots, with a dropdown to choose channel number."""
@@ -890,7 +905,6 @@ class Channel:
                 good_expr = good_expr.and_(this_iter_good_expr)
         return self.with_good_expr(good_expr, replace)
 
-    @functools.cache
     def typical_peak_ind(self, col: str = "pulse") -> int:
         """Return the typical peak index of the given column, using the median peak index for the first 100 pulses."""
         assert self.pulseframer is not None
@@ -1374,17 +1388,10 @@ class Channel:
 
     def __hash__(self) -> int:
         """Return a hash based on the object's id."""
-        # needed to make functools.cache work
-        # if self or self.anything is mutated, assumptions will be broken
-        # and we may get nonsense results
         return hash(id(self))
 
     def __eq__(self, other: object) -> bool:
         """Return True if the other object is the same object (by id)."""
-        # needed to make functools.cache work
-        # if self or self.anything is mutated, assumptions will be broken
-        # and we may get nonsense results
-        # only checks if the ids match, does not try to be equal if all contents are equal
         return id(self) == id(other)
 
     @classmethod
@@ -1404,6 +1411,8 @@ class Channel:
         ljh = mass2.LJHFile.open(path, max_pulses=max_pulses)
         df, header_df = ljh.to_polars(keep_posix_usec)
         header = ChannelHeader.from_ljh_header_df(header_df)
+        if noise_path:
+            header = dataclasses.replace(header, noise_data_source=str(noise_path))
         channel = cls(
             df,
             header=header,
@@ -1519,7 +1528,7 @@ class Channel:
             nch = None
         else:
             ndata = load(noise_fname)
-            _, nnoise = pdata.shape
+            _, nnoise = ndata.shape
             noise_df = pl.DataFrame({"index": range(nnoise)})
             noise_header = pl.DataFrame({
                 "filename": noise_fname,
@@ -1563,10 +1572,6 @@ class Channel:
         holding the data from all 5 objects, plus a new column named "element", which will be one of
         {"Be", "Fe", "Ge", "Se", "Xe"}, according to which LJH file it came from.
 
-        BEWARE: this will entail a copy of all raw data in all input LJH files, as far as we know.
-        That's a memory-intensive request. Use for small files only, or for `Channel` objects that are
-        no longer connected directly to raw pulse files!
-
         Parameters
         ----------
         sourcename : str
@@ -1584,12 +1589,18 @@ class Channel:
         # We'll copy the header and other non-dataframe stuff from the first constituent.
         combined_chan = next(iter(constituents.values()))
         df = pl.DataFrame()
+        framers: list[PulseDataFramer | None] = []
+        sources: list[str | None] = []
         for k, ch in constituents.items():
             assert ch.frametime_s == combined_chan.frametime_s
             assert ch.n_presamples == combined_chan.n_presamples
             assert ch.n_samples == combined_chan.n_samples
             df = df.vstack(ch.df.with_columns(pl.lit(k).alias(sourcename)))
-        return replace(combined_chan, df=df, npulses=len(df))
+            framers.append(ch.pulseframer)
+            sources.extend(ch.header.leaf_data_sources())
+        combined_pulseframer = mass2.core.misc.concat_pulseframers(framers)
+        header = replace(combined_chan.header, data_source=None, pulse_data_sources=tuple(sources))
+        return replace(combined_chan, header=header, df=df, npulses=len(df), pulseframer=combined_pulseframer)
 
     def with_experiment_state_df(self, df_es: pl.DataFrame, force_timestamp_monotonic: bool = False) -> "Channel":
         """Add experiment states from an existing dataframe"""
@@ -1723,25 +1734,43 @@ class Channel:
         )
         return self.with_step(step)
 
-    def concat_df(self, df: pl.DataFrame) -> "Channel":
+    def concat_df(self, df: pl.DataFrame, pulseframer: PulseDataFramer | None = None) -> "Channel":
         """Concat the given dataframe to the existing dataframe, keeping all other attributes the same.
-        If the new frame `df` has a history and/or steps, those will be lost"""
+        If the new frame `df` has a history and/or steps, those will be lost.
+
+        Parameters
+        ----------
+        df : pl.DataFrame
+            Rows to append after this channel's existing rows.
+        pulseframer : PulseDataFramer | None, optional
+            A source of raw pulses for the rows of `df`, by default None. When given (and this channel
+            already has a `pulseframer`), the result's `pulseframer` serves raw pulses from both sources,
+            in order. If omitted, the result's `pulseframer` is None, since raw pulses for the appended
+            rows would otherwise be unavailable.
+        """
+        combined_df = mass2.core.misc.concat_dfs_with_concat_state(self.df, df)
+        combined_pulseframer = mass2.core.misc.concat_pulseframers([self.pulseframer, pulseframer])
+        sources = self.header.leaf_data_sources() + (None,)
+        header = replace(self.header, data_source=None, pulse_data_sources=sources)
         ch2 = Channel(
-            mass2.core.misc.concat_dfs_with_concat_state(self.df, df),
-            self.header,
-            self.npulses,
+            combined_df,
+            header,
+            len(combined_df),
             subframediv=self.subframediv,
             noise=self.noise,
             good_expr=self.good_expr,
+            pulseframer=combined_pulseframer,
         )
         # we won't copy over df_history and steps. I don't think you should use this when those are filled in?
         return ch2
 
     def concat_ch(self, ch: "Channel") -> "Channel":
-        """Concat the given channel's dataframe to the existing dataframe, keeping all other attributes the same.
-        If the new channel `ch` has a history and/or steps, those will be lost"""
-        ch2 = self.concat_df(ch.df)
-        return ch2
+        """Concat the given channel's dataframe (and raw-pulse source) to this one's, keeping all other
+        attributes the same. If the new channel `ch` has a history and/or steps, those will be lost"""
+        result = self.concat_df(ch.df, pulseframer=ch.pulseframer)
+        sources = self.header.leaf_data_sources() + ch.header.leaf_data_sources()
+        header = replace(result.header, data_source=None, pulse_data_sources=sources)
+        return replace(result, header=header)
 
     def phase_correct_mass_specific_lines(
         self,
@@ -1802,7 +1831,7 @@ class Channel:
             (pl.col("rise_time") * 1e6).alias("rise_time_µs"),
         )
 
-        tpi_microsec = df.filter(self.good_expr).select("peak_time_µs").median().collect()
+        tpi_microsec = df.filter(self.good_expr).select("peak_time_µs").median().collect().item()
         plottables = (
             ("pulse_rms", "Pulse RMS", "#dd00ff", None),
             ("pulse_average", "Pulse Avg", "purple", None),

--- a/mass2/core/channels.py
+++ b/mass2/core/channels.py
@@ -11,7 +11,6 @@ import polars as pl
 import pylab as plt
 import matplotlib
 import numpy as np
-import functools
 import joblib
 import traceback
 import lmfit
@@ -66,7 +65,6 @@ class Channels:
         descr = self.description + more.description + "\nWarning! created by with_more_channels()"
         return dataclasses.replace(self, channels=channels, bad_channels=bad, description=descr)
 
-    @functools.cache
     def dfg(self, exclude: str = "pulse") -> pl.DataFrame:
         """Return a DataFrame containing good pulses from each channel. Excludes the given columns (default "pulse")."""
         # return a dataframe containing good pulses from each channel,
@@ -396,9 +394,6 @@ class Channels:
 
     def __hash__(self) -> int:
         """Hash based on the object's id (identity)."""
-        # needed to make functools.cache work
-        # if self or self.anything is mutated, assumptions will be broken
-        # and we may get nonsense results
         return hash(id(self))
 
     def __eq__(self, other: Any) -> bool:
@@ -680,7 +675,12 @@ class Channels:
             ch = self.channels[ch_num]
             other_ch = other_data.channels[ch_num]
             combined_df = mass2.core.misc.concat_dfs_with_concat_state(ch.df, other_ch.df)
-            new_ch = ch.with_replacement_df(combined_df)
+            combined_pulseframer = mass2.core.misc.concat_pulseframers([ch.pulseframer, other_ch.pulseframer])
+            sources = ch.header.leaf_data_sources() + other_ch.header.leaf_data_sources()
+            header = dataclasses.replace(ch.header, data_source=None, pulse_data_sources=sources)
+            new_ch = dataclasses.replace(
+                ch, header=header, df=combined_df, npulses=len(combined_df), pulseframer=combined_pulseframer
+            )
             new_channels[ch_num] = new_ch
         return mass2.Channels(new_channels, self.description + other_data.description)
 
@@ -694,9 +694,6 @@ class Channels:
         """Combine 2 or more compatible `mass2.Channels` objects into one. See `mass2.Channel.combine_channels()`
         for more info about what "compatible" might mean. Certainly all `Channel` objects should have equal
         `n_samples`, `n_presamples`, and `frametime_s`.
-
-        BEWARE: this will entail a copy of all raw data in all input LJH files, as far as we know.
-        That's a memory-intensive request. Use for small files only!
 
         Parameters
         ----------
@@ -846,17 +843,31 @@ class Channels:
             Channel
                 The Channel `ch` but with `ch.df` updated, including any raw data backed by an LJH file
             """
-            # If this channel was based on an LJH file, restore columns from the LJH file to the dataframe.
-            if ch.header.data_source is not None:
-                ljh_path = ch.header.data_source
-                if ljh_path.endswith(".ljh") or ljh_path.endswith(".noi"):
-                    ljh_backed_chan = Channel.from_ljh(ljh_path)
+            def _reload_leaf_chan(data_source: str | None) -> Channel | None:
+                """Reopen a single leaf raw-data path, if it's a file type mass2 knows how to reload."""
+                if data_source is not None and (data_source.endswith(".ljh") or data_source.endswith(".noi")):
+                    return Channel.from_ljh(data_source)
+                return None
+
+            pulseframer = None
+            sources = ch.header.pulse_data_sources
+            if sources is not None:
+                restored_parts = [_reload_leaf_chan(src) for src in sources]
+                found_parts = [part for part in restored_parts if part is not None]
+                if restored_parts and len(found_parts) == len(restored_parts):
+                    raw_df = pl.concat([part.df for part in found_parts], how="vertical")
+                    df = df.with_columns(raw_df)
+                    pulseframer = mass2.core.misc.concat_pulseframers([part.pulseframer for part in found_parts])
+            else:
+                ljh_backed_chan = _reload_leaf_chan(ch.header.data_source)
+                if ljh_backed_chan is not None:
                     df = df.with_columns(ljh_backed_chan.df)
-            # df_history is needed for some debug plots to work. This version has strictly more columns than required
-            # at each history point. TODO: We could use the steps inputs and outputs to trim the appropriate columns.
-            # For getting started, though, it's easier just to let each dataframe in history equal the final dataframe.
+                    pulseframer = ljh_backed_chan.pulseframer
             df_history = [df] * len(ch.steps)
-            return dataclasses.replace(ch, df=df, df_history=df_history)
+            noise = None
+            if ch.header.noise_data_source is not None:
+                noise = mass2.NoiseChannel.from_ljh(ch.header.noise_data_source)
+            return dataclasses.replace(ch, df=df, df_history=df_history, pulseframer=pulseframer, noise=noise)
 
         with ZipFile(path, "r") as zf:
             pickle_file = "data_all.pkl"

--- a/mass2/core/ljhfiles.py
+++ b/mass2/core/ljhfiles.py
@@ -6,7 +6,7 @@ import dataclasses
 from dataclasses import dataclass
 from pathlib import Path
 from typing import ClassVar, Any
-from collections.abc import Iterable, Generator
+from collections.abc import Iterable
 from numpy.typing import NDArray
 import os
 import numpy as np
@@ -301,10 +301,6 @@ class LJHFile(PulseDataFramer):
         schema = pl.Schema({"pulse": pl.Array(pl.UInt16, self.nsamples)})
         df = pl.DataFrame(data, schema=schema)
         return df
-
-    def iterate_raw_pulses(self, chunksize: int, extra_fields: Iterable[str] = []) -> Generator[pl.DataFrame]:
-        for i in range(0, self.npulses, chunksize):
-            yield self.load_raw_chunk(i, i + chunksize)
 
     def to_polars(
         self,

--- a/mass2/core/misc.py
+++ b/mass2/core/misc.py
@@ -3,13 +3,12 @@ Miscellaneous utility functions used in mass2 for plotting, pickling, statistics
 """
 
 from numpy.typing import ArrayLike, NDArray
-from typing import Any
+from typing import Any, TYPE_CHECKING
 from pathlib import Path
 import numpy as np
 import pylab as plt
 import polars as pl
 import dill
-import mmap
 import pathlib
 import subprocess
 import sys
@@ -235,6 +234,10 @@ class PulseDataFramer(ABC):
     """Classes that inherit from this can provide specified chunks of raw pulses, or specific pulses, as
     polars DataFrame objects."""
 
+    if TYPE_CHECKING:
+        @property
+        def npulses(self) -> int: ...
+
     @abstractmethod
     def load_raw_chunk(self, start: int, stop: int, step: int = 1, extra_fields: Iterable[str] = []) -> pl.DataFrame: ...
 
@@ -244,8 +247,101 @@ class PulseDataFramer(ABC):
     @abstractmethod
     def load_raw_pulses(self, ids: Iterable[int], extra_fields: Iterable[str] = []) -> pl.DataFrame: ...
 
-    @abstractmethod
-    def iterate_raw_pulses(self, chunksize: int, extra_fields: Iterable[str] = []) -> Generator[pl.DataFrame]: ...
+    def iterate_raw_pulses(self, chunksize: int, extra_fields: Iterable[str] = []) -> Generator[pl.DataFrame]:
+        """Yield successive chunks of `chunksize` raw pulses each, covering the whole source in order."""
+        for i in range(0, self.npulses, chunksize):
+            yield self.load_raw_chunk(i, i + chunksize, extra_fields=extra_fields)
+
+    def select_rows(self, indices: ArrayLike) -> "PulseDataFramer":
+        """Return a new PulseDataFramer serving rows `indices[0], indices[1], ...` of this one, in that
+        order (repeats allowed). Used to keep a Channel's `pulseframer` in sync with its dataframe after
+        row-reordering operations such as `head`, `tail`, or `sample`."""
+        return ReindexedPulseDataFramer(self, np.asarray(indices, dtype=np.int64))
+
+
+@dataclass(frozen=True)
+class ReindexedPulseDataFramer(PulseDataFramer):
+    """Wraps another PulseDataFramer, remapping virtual row `i` to `base` row `indices[i]`."""
+
+    base: PulseDataFramer
+    indices: NDArray
+
+    @property
+    def npulses(self) -> int:
+        return len(self.indices)
+
+    def load_raw_chunk(self, start: int, stop: int, step: int = 1, extra_fields: Iterable[str] = []) -> pl.DataFrame:
+        stop = min(stop, self.npulses)
+        return self.base.load_raw_pulses(self.indices[start:stop:step], extra_fields=extra_fields)
+
+    def load_raw_pulse(self, id: int, extra_fields: Iterable[str] = []) -> pl.DataFrame:
+        return self.base.load_raw_pulse(int(self.indices[id]), extra_fields=extra_fields)
+
+    def load_raw_pulses(self, ids: Iterable[int], extra_fields: Iterable[str] = []) -> pl.DataFrame:
+        ids = np.asarray(list(ids), dtype=np.int64)
+        return self.base.load_raw_pulses(self.indices[ids], extra_fields=extra_fields)
+
+
+@dataclass(frozen=True)
+class ConcatPulseDataFramer(PulseDataFramer):
+    """Wraps a sequence of PulseDataFramers end-to-end, presenting them as one contiguous source, so that
+    concatenated or combined Channels (e.g. via `concat_ch`, `combine_channels`) can still fetch raw
+    pulses correctly from each of their constituent source files."""
+
+    parts: tuple[PulseDataFramer, ...]
+
+    def __post_init__(self) -> None:
+        assert len(self.parts) > 0, "ConcatPulseDataFramer needs at least one part"
+
+    @property
+    def _part_lengths(self) -> NDArray:
+        return np.array([p.npulses for p in self.parts], dtype=np.int64)
+
+    @property
+    def _offsets(self) -> NDArray:
+        """Cumulative pulse count before each part; `_offsets[i]` is the first virtual row index of `parts[i]`."""
+        return np.concatenate(([0], np.cumsum(self._part_lengths)))
+
+    @property
+    def npulses(self) -> int:
+        return int(self._part_lengths.sum())
+
+    def load_raw_pulse(self, id: int, extra_fields: Iterable[str] = []) -> pl.DataFrame:
+        offsets = self._offsets
+        part_i = int(np.searchsorted(offsets, id, side="right") - 1)
+        local_id = int(id - offsets[part_i])
+        return self.parts[part_i].load_raw_pulse(local_id, extra_fields=extra_fields)
+
+    def load_raw_pulses(self, ids: Iterable[int], extra_fields: Iterable[str] = []) -> pl.DataFrame:
+        ids_arr = np.asarray(list(ids), dtype=np.int64)
+        if len(ids_arr) == 0:
+            return self.parts[0].load_raw_pulses([], extra_fields=extra_fields)
+        offsets = self._offsets
+        part_idx = np.searchsorted(offsets, ids_arr, side="right") - 1
+        dfs = []
+        positions = []
+        for p in np.unique(part_idx):
+            mask = part_idx == p
+            local_ids = ids_arr[mask] - offsets[p]
+            dfs.append(self.parts[int(p)].load_raw_pulses(local_ids, extra_fields=extra_fields))
+            positions.append(np.nonzero(mask)[0])
+        combined = pl.concat(dfs, how="vertical")
+        order = np.concatenate(positions)
+        if np.array_equal(order, np.arange(len(order))):
+            return combined
+        return combined.with_columns(pl.Series("__concat_order__", order)).sort("__concat_order__").drop("__concat_order__")
+
+    def load_raw_chunk(self, start: int, stop: int, step: int = 1, extra_fields: Iterable[str] = []) -> pl.DataFrame:
+        stop = min(stop, self.npulses)
+        if step == 1 and stop > start:
+            offsets = self._offsets
+            start_part = int(np.searchsorted(offsets, start, side="right") - 1)
+            stop_part = int(np.searchsorted(offsets, stop - 1, side="right") - 1)
+            if start_part == stop_part:
+                local_start = int(start - offsets[start_part])
+                local_stop = int(stop - offsets[start_part])
+                return self.parts[start_part].load_raw_chunk(local_start, local_stop, extra_fields=extra_fields)
+        return self.load_raw_pulses(range(start, stop, step), extra_fields=extra_fields)
 
 
 @dataclass(frozen=True)
@@ -267,47 +363,13 @@ class PulseDataFromNumpy(PulseDataFramer):
     def load_raw_pulses(self, ids: Iterable[int], extra_fields: Iterable[str] = []) -> pl.DataFrame:
         return pl.DataFrame({"pulse": self.pulses[list(ids)]})
 
-    def iterate_raw_pulses(self, chunksize: int, extra_fields: Iterable[str] = []) -> Generator[pl.DataFrame]:
-        for i in range(0, self.npulses, chunksize):
-            yield pl.DataFrame({"pulse": self.pulses[i : i + chunksize]})
 
-
-def hunt_for_mmap(obj: Any, path: str = "root_object", visited: set[Any] | None = None) -> None:
-    """A function to search recursively for an object to contain an unpicklable mmap."""
-    if visited is None:
-        visited = set()
-
-    # Prevent infinite loops from circular references
-    obj_id = id(obj)
-    if obj_id in visited:
-        return
-    visited.add(obj_id)
-
-    # Base Case 1: Found the raw mmap
-    if isinstance(obj, mmap.mmap):
-        print(f"🚨 FOUND RAW MMAP AT: {path}")
-        return
-
-    # Base Case 2: Found a NumPy memmap (which contains an mmap)
-    if isinstance(obj, np.memmap):
-        print(f"🚨 FOUND NUMPY MEMMAP AT: {path}")
-        return
-
-    # Recursive Step 1: Check dictionaries
-    if isinstance(obj, dict):
-        for key, value in obj.items():
-            hunt_for_mmap(value, f"{path}['{key}']", visited)
-
-    # Recursive Step 2: Check lists and tuples
-    elif isinstance(obj, (list, tuple)):
-        for index, item in enumerate(obj):
-            hunt_for_mmap(item, f"{path}[{index}]", visited)
-
-    # Recursive Step 3: Check custom objects / dataclasses
-    elif hasattr(obj, "__dict__"):
-        for key, value in obj.__dict__.items():
-            hunt_for_mmap(value, f"{path}.{key}", visited)
-
-
-# Run the hunter
-# hunt_for_mmap(my_failing_dataclass)
+def concat_pulseframers(framers: Iterable["PulseDataFramer | None"]) -> "PulseDataFramer | None":
+    """Combine a sequence of per-source PulseDataFramers into one that serves their raw pulses end-to-end,
+    in order. Returns None if any input is None, since raw pulses for that part would then be unavailable."""
+    parts = list(framers)
+    if any(p is None for p in parts):
+        return None
+    if len(parts) == 1:
+        return parts[0]
+    return ConcatPulseDataFramer(tuple(parts))  # type: ignore[arg-type]

--- a/mass2/core/noise_channel.py
+++ b/mass2/core/noise_channel.py
@@ -20,7 +20,7 @@ class NoiseChannel:
     df: pl.DataFrame  # DO NOT MUTATE THIS!!!
     header_df: pl.DataFrame  # DO NOT MUTATE THIS!!
     frametime_s: float
-    pulseframer: PulseDataFramer | None
+    pulseframer: PulseDataFramer | None = None
 
     # @functools.cache
     def calc_max_excursion(


### PR DESCRIPTION
Raw pulses could be misaligned or unreachable after head/tail/sample/concat_ch/combine_channels.

Fix: keep PulseDataFramer in sync with DataFrame.
When the DataFrame is updated, the PulseDataFramer is also accordingly updated.