### PR TITLE
`PretrigMeanJumpFixStep` works if not time ordered

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,7 @@
 
 **2.1.0** June 24, 2026-
 * Remove raw pulse storage from the primary `Channel.df` dataframe (issue 126).
+* Make pretrig mean jump correction work with non-time-ordered data (issue 166).
 
 **2.0.5** June 11, 2026
 * Fix typo in Getting Started doc that can shadow `range` and screw up your iPython session (issue 137).

--- a/mass2/core/channel.py
+++ b/mass2/core/channel.py
@@ -940,7 +940,7 @@ class Channel:
     ) -> "Channel":
         """Correct pretrigger mean jumps in the raw pulse data, writing to a new column."""
         step = mass2.core.recipe.PretrigMeanJumpFixStep(
-            inputs=[uncorrected],
+            inputs=[uncorrected, "subframecount"],
             output=[corrected],
             good_expr=self.good_expr,
             use_expr=pl.lit(True),

--- a/mass2/core/recipe.py
+++ b/mass2/core/recipe.py
@@ -62,14 +62,39 @@ class RecipeStep(ABC):
 
 @dataclass(frozen=True)
 class PretrigMeanJumpFixStep(RecipeStep):
-    """A step to fix jumps in the pretrigger mean by unwrapping the phase angle, a periodic quantity."""
+    """A step to fix jumps in the pretrigger mean by unwrapping the phase angle, a periodic quantity
 
-    period: float
+    self.inputs name the following fields in the input pl.Dataframe:
+        [0] The pretrigger mean field that needs to have flux jumps removed.
+        [1] Any field that indicates strict time-ordering, generally "subframecount".
+    """
+
+    period: float  # Periodicity to be removed, typically 4096 or other power of 2.
 
     def calc_from_df(self, df: pl.DataFrame, pulseframer: PulseDataFramer | None = None) -> pl.DataFrame:
-        """Calculate the jump-corrected pretrigger mean and return a new DataFrame."""
-        ptm1 = df[self.inputs[0]].to_numpy()
+        """Calculate the jump-corrected pretrigger mean and return a new DataFrame.
+
+        Thanks to fixing [issue 166](https://github.com/usnistgov/mass2/issues/166),
+        this will work whether or not the dataframe is already in time order.
+        """
+        ptmean_name, orderingfield_name = self.inputs
+        ptm1 = df[ptmean_name].to_numpy()
+
+        # Use the second column named in self.inputs as a strict time-ordering column.
+        # Generally this will prove to be already in order. But if it isn't, reorder the
+        # pretrigger means, apply the unwrap algorithm, and then restore the original ordering.
+        timeorder = df[orderingfield_name].to_numpy()
+        already_in_timeorder = np.all(timeorder[1:] >= timeorder[:-1])
+        if not already_in_timeorder:
+            sort_idx = timeorder.argsort()
+            ptm1 = ptm1[sort_idx]
         ptm2 = np.unwrap(ptm1 % self.period, period=self.period)
+        if not already_in_timeorder:
+            # The following is an O(N) algorithm,
+            # whereas restore_idx = np.argsort(sort_idx) would work, but it takes O(N log N)
+            restore_idx = np.empty_like(sort_idx)
+            restore_idx[sort_idx] = np.arange(len(sort_idx))
+            ptm2 = ptm2[restore_idx]
         df2 = pl.DataFrame({self.output[0]: ptm2}).with_columns(df)
         return df2
 

--- a/tests/core/test_channels.py
+++ b/tests/core/test_channels.py
@@ -24,7 +24,8 @@ def test_ljh_to_polars():
 def dummy_dataframe(npulses: int) -> pl.DataFrame:
     """Generate a dataframe with `npulses` rows. The Python API requires keeping a column in it, or it will
     have zero rows."""
-    return pl.DataFrame({"_dummy": range(npulses)})
+    idx = np.arange(npulses)
+    return pl.DataFrame({"_dummy": idx, "subframecount": idx * 100000})
 
 
 def dummy_channel(npulses=100, seed=4, signal=np.zeros(50, dtype=np.int16), ch_num: int = 0):
@@ -389,7 +390,7 @@ def test_pretrig_mean_jump_fix_step():
     ch2 = ch.correct_pretrig_mean_jumps(period=50)
     assert all(np.diff(ch2.df["ptm_jf"].to_numpy()) == 1)
     step = ch2.steps[-1]
-    assert step.inputs == ["pretrig_mean"]
+    assert step.inputs == ["pretrig_mean", "subframecount"]
     assert step.output == ["ptm_jf"]
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpfilename = os.path.join(tmpdir, "steps.pkl")
@@ -650,3 +651,36 @@ def test_ch_from_numpy2():
     for i in range(ch.npulses):
         pulse = raw_df["pulse"][i].to_numpy()
         assert np.all(pulse < 5000) and np.all(pulse > -5000)
+
+
+def test_flux_jump_correction_non_time_ordered_data():
+    """Check for [issue 166](https://github.com/usnistgov/mass2/issues/166)
+
+    Test that flux-jump correction still works even if raw data are re-ordered.
+    """
+    PERIOD = 4096
+    Npulses = 40
+    steps = 400
+    ptm_jumpy = np.arange(Npulses, dtype=np.float32) * steps + 2000
+    assert ptm_jumpy[-1] - ptm_jumpy[0] > PERIOD  # If not, you're not really testing the problem
+    ptm_correct = ptm_jumpy.copy()
+    ptm_jumpy[10:20] += 2 * PERIOD
+    info = {"pretrig_mean": ptm_jumpy, "subframecount": np.arange(Npulses) * 10000000}
+    df = pl.DataFrame(info)
+    header = mass2.ChannelHeader("", None, 100, 1e-5, 100, 200, pl.DataFrame())
+    ch = mass2.Channel(df, header, Npulses)
+
+    # First, make sure that correct_pretrig_mean_jumps works as expected: creating column "ptm_jf"
+    # with the corrected values.
+    assert np.all(df["pretrig_mean"].to_numpy() == ptm_jumpy)
+    ch1 = ch.correct_pretrig_mean_jumps(period=PERIOD)
+    assert np.all(ch1.df["pretrig_mean"].to_numpy() == ptm_jumpy)
+    assert np.all(ch1.df["ptm_jf"].to_numpy() == ptm_correct)
+
+    # Now test for issue 166, where a time-unordered data set fails.
+    shuffled_df = ch.df.sample(fraction=1.0, shuffle=True, seed=91)
+    ch2 = dataclasses.replace(ch, df=shuffled_df)
+
+    ch3 = ch2.correct_pretrig_mean_jumps(period=PERIOD)
+    sort_idx = ch3.df["subframecount"].to_numpy().argsort()
+    assert np.all(ch3.df["ptm_jf"].to_numpy()[sort_idx] == ptm_correct)


### PR DESCRIPTION
In `PretrigMeanJumpFixStep`, check whether the data are time-ordered already. If not, sort back into time order to perform the flux-jump removal algorithm, and then re-arrange into the original order.
Fixes #166.